### PR TITLE
Start passing parameters to rule invokation

### DIFF
--- a/cfripper/model/rule_processor.py
+++ b/cfripper/model/rule_processor.py
@@ -30,7 +30,7 @@ class Rule:
         self._config = config if config else Config()
         self._result = result
 
-    def invoke(self, resources):
+    def invoke(self, resources, parameters):
         raise NotImplementedError("Can't process the base Rule class.")
 
     def process_resource(self, logical_name, properties):
@@ -60,7 +60,7 @@ class RuleProcessor:
 
         for rule in self.rules:
             try:
-                rule.invoke(cf_model.resources)
+                rule.invoke(cf_model.resources, cf_model.parameters)
             except Exception as other_exception:
                 logger.error("{} crashed with {} for project - {}, service- {}, stack - {}".format(
                     type(rule).__name__,

--- a/cfripper/rules/CloudFormationAuthenticationRule.py
+++ b/cfripper/rules/CloudFormationAuthenticationRule.py
@@ -22,7 +22,7 @@ class CloudFormationAuthenticationRule(Rule):
     REASON = "Possible hardcoded credentials in {}"
     MONITOR_MODE = True
 
-    def invoke(self, resources):
+    def invoke(self, resources, parameters):
         for name, resource_list in resources.items():
             for resource in resource_list:
                 if resource.has_hardcoded_credentials():

--- a/cfripper/rules/CrossAccountTrustRule.py
+++ b/cfripper/rules/CrossAccountTrustRule.py
@@ -27,7 +27,7 @@ class CrossAccountTrustRule(Rule):
     MONITOR_MODE = True
     ROOT_PATTERN = re.compile(r"arn:aws:iam::\d*:root")
 
-    def invoke(self, resources):
+    def invoke(self, resources, parameters):
         for resource in resources.get("AWS::IAM::Role", []):
             arpd = resource.assume_role_policy_document
             for statement in arpd.statements:

--- a/cfripper/rules/EBSVolumeHasSSERule.py
+++ b/cfripper/rules/EBSVolumeHasSSERule.py
@@ -22,7 +22,7 @@ class EBSVolumeHasSSERule(Rule):
     REASON = "EBS volume {} should have server-side encryption enabled"
     MONITOR_MODE = True
 
-    def invoke(self, resources):
+    def invoke(self, resources, parameters):
         for resource in resources.get("AWS::EC2::Volume", []):
             if hasattr(resource, "encrypted") and resource.encrypted is True:
                 continue

--- a/cfripper/rules/IAMManagedPolicyWildcardActionRule.py
+++ b/cfripper/rules/IAMManagedPolicyWildcardActionRule.py
@@ -22,7 +22,7 @@ class IAMManagedPolicyWildcardActionRule(Rule):
     REASON = "IAM managed policy {} should not allow * action"
     MONITOR_MODE = True
 
-    def invoke(self, resources):
+    def invoke(self, resources, parameters):
         for resource in resources.get("AWS::IAM::ManagedPolicy", []):
             if resource.policy_document.wildcard_allowed_actions(pattern=r"^(\w*:){0,1}\*$"):
                 self.add_failure(

--- a/cfripper/rules/IAMRoleWildcardActionOnPermissionsPolicyRule.py
+++ b/cfripper/rules/IAMRoleWildcardActionOnPermissionsPolicyRule.py
@@ -22,7 +22,7 @@ class IAMRoleWildcardActionOnPermissionsPolicyRule(Rule):
     REASON = "IAM role {} should not allow * action on its permissions policy {}"
     MONITOR_MODE = False
 
-    def invoke(self, resources):
+    def invoke(self, resources, parameters):
         for resource in resources.get("AWS::IAM::Role", []):
             for policy in resource.policies:
                 if policy.policy_document.wildcard_allowed_actions(pattern=r"^(\w*:){0,1}\*$"):

--- a/cfripper/rules/IAMRoleWildcardActionOnTrustPolicyRule.py
+++ b/cfripper/rules/IAMRoleWildcardActionOnTrustPolicyRule.py
@@ -22,7 +22,7 @@ class IAMRoleWildcardActionOnTrustPolicyRule(Rule):
     REASON = "IAM role {} should not allow * action on its trust policy"
     MONITOR_MODE = True
 
-    def invoke(self, resources):
+    def invoke(self, resources, parameters):
         for resource in resources.get("AWS::IAM::Role", []):
             if resource.assume_role_policy_document.wildcard_allowed_actions(pattern=r"^(\w*:){0,1}\*$"):
                 self.add_failure(

--- a/cfripper/rules/IAMRolesOverprivilegedRule.py
+++ b/cfripper/rules/IAMRolesOverprivilegedRule.py
@@ -22,7 +22,7 @@ logger = get_logger()
 
 class IAMRolesOverprivilegedRule(Rule):
 
-    def invoke(self, resources):
+    def invoke(self, resources, parameters):
         for resource in resources.get("AWS::IAM::Role", []):
             self.process_resource(resource.logical_id, resource)
 

--- a/cfripper/rules/ManagedPolicyOnUserRule.py
+++ b/cfripper/rules/ManagedPolicyOnUserRule.py
@@ -22,7 +22,7 @@ class ManagedPolicyOnUserRule(Rule):
     REASON = "IAM managed policy {} should not apply directly to users. Should be on group"
     MONITOR_MODE = True
 
-    def invoke(self, resources):
+    def invoke(self, resources, parameters):
         for resource in resources.get("AWS::IAM::ManagedPolicy", []):
             if resource.users:
                 self.add_failure(

--- a/cfripper/rules/PolicyOnUserRule.py
+++ b/cfripper/rules/PolicyOnUserRule.py
@@ -22,7 +22,7 @@ class PolicyOnUserRule(Rule):
     REASON = "IAM policy {} should not apply directly to users. Should be on group"
     MONITOR_MODE = True
 
-    def invoke(self, resources):
+    def invoke(self, resources, parameters):
         for resource in resources.get("AWS::IAM::Policy", []):
             if resource.users:
                 self.add_failure(

--- a/cfripper/rules/PrivilegeEscalationRule.py
+++ b/cfripper/rules/PrivilegeEscalationRule.py
@@ -40,7 +40,7 @@ class PrivilegeEscalationRule(Rule):
         ]
     )
 
-    def invoke(self, resources):
+    def invoke(self, resources, parameters):
         for resource in resources.get("AWS::IAM::Policy", []):
             actions = set(resource.policy_document.get_iam_actions())
             intersection = actions.intersection(self.IAM_BLACKLIST)

--- a/cfripper/rules/S3BucketPolicyPrincipalRule.py
+++ b/cfripper/rules/S3BucketPolicyPrincipalRule.py
@@ -23,7 +23,7 @@ class S3BucketPolicyPrincipalRule(Rule):
     MONITOR_MODE = True
     AWS_PRINCIPALS = []  # add principals here
 
-    def invoke(self, resources):
+    def invoke(self, resources, parameters):
         for resource in resources.get("AWS::S3::BucketPolicy", []):
             non_whitelisted = resource.policy_document.nonwhitelisted_allowed_principals(self.AWS_PRINCIPALS)
             if non_whitelisted:

--- a/cfripper/rules/S3BucketPolicyWildcardActionRule.py
+++ b/cfripper/rules/S3BucketPolicyWildcardActionRule.py
@@ -22,7 +22,7 @@ class S3BucketPolicyWildcardActionRule(Rule):
     REASON = "S3 Bucket policy {} should not allow * action"
     MONITOR_MODE = False
 
-    def invoke(self, resources):
+    def invoke(self, resources, parameters):
         for resource in resources.get("AWS::S3::BucketPolicy", []):
             if resource.policy_document.wildcard_allowed_actions(pattern=r"^(\w*:){0,1}\*$"):
                 self.add_failure(

--- a/cfripper/rules/S3BucketPublicReadAclAndListStatementRule.py
+++ b/cfripper/rules/S3BucketPublicReadAclAndListStatementRule.py
@@ -25,7 +25,7 @@ class S3BucketPublicReadAclAndListStatementRule(Rule):
     REASON = "S3 Bucket {} should not have a public read acl and list bucket statement"
     MONITOR_MODE = True
 
-    def invoke(self, resources):
+    def invoke(self, resources, parameters):
         # Get all bucket policies and filter to get the ones that allow list actions
         bucket_policies = []
         for policy in resources.get("AWS::S3::BucketPolicy", []):

--- a/cfripper/rules/S3BucketPublicReadWriteAclRule.py
+++ b/cfripper/rules/S3BucketPublicReadWriteAclRule.py
@@ -25,7 +25,7 @@ class S3BucketPublicReadWriteAclRule(Rule):
     REASON = "S3 Bucket {} should not have a public read-write acl"
     MONITOR_MODE = False
 
-    def invoke(self, resources):
+    def invoke(self, resources, parameters):
         for resource in resources.get("AWS::S3::Bucket", []):
             try:
                 if resource.access_control == "PublicReadWrite":

--- a/cfripper/rules/S3CrossAccountTrustRule.py
+++ b/cfripper/rules/S3CrossAccountTrustRule.py
@@ -25,7 +25,7 @@ class S3CrossAccountTrustRule(Rule):
     REASON = "{} has forbidden cross-account policy allow with {} for an S3 bucket."
     MONITOR_MODE = True
 
-    def invoke(self, resources):
+    def invoke(self, resources, parameters):
         for resource in resources.get("AWS::S3::BucketPolicy", []):
             for statement in resource.policy_document.statements:
                 if statement.effect == "Allow":

--- a/cfripper/rules/SNSTopicPolicyNotPrincipalRule.py
+++ b/cfripper/rules/SNSTopicPolicyNotPrincipalRule.py
@@ -21,7 +21,7 @@ class SNSTopicPolicyNotPrincipalRule(Rule):
     REASON = "SNS Topic {} policy should not allow Allow+NotPrincipal"
     MONITOR_MODE = True
 
-    def invoke(self, resources):
+    def invoke(self, resources, parameters):
         for resource in resources.get("AWS::SNS::TopicPolicy", []):
             if resource.policy_document.allows_not_principal():
                 self.add_failure(

--- a/cfripper/rules/SQSQueuePolicyNotPrincipalRule.py
+++ b/cfripper/rules/SQSQueuePolicyNotPrincipalRule.py
@@ -21,7 +21,7 @@ class SQSQueuePolicyNotPrincipalRule(Rule):
     REASON = "SQS Queue {} policy should not allow Allow+NotPrincipal"
     MONITOR_MODE = True
 
-    def invoke(self, resources):
+    def invoke(self, resources, parameters):
         for resource in resources.get("AWS::SQS::QueuePolicy", []):
             if resource.policy_document.allows_not_principal():
                 self.add_failure(

--- a/cfripper/rules/SQSQueuePolicyPublicRule.py
+++ b/cfripper/rules/SQSQueuePolicyPublicRule.py
@@ -22,7 +22,7 @@ class SQSQueuePolicyPublicRule(Rule):
     REASON = "SQS Queue policy {} should not be public"
     MONITOR_MODE = False
 
-    def invoke(self, resources):
+    def invoke(self, resources, parameters):
         for resource in resources.get("AWS::SQS::QueuePolicy", []):
             if resource.policy_document.wildcard_allowed_principals(pattern=r"^(\w*:){0,1}\*$"):
                 for statement in resource.policy_document.statements:

--- a/cfripper/rules/SQSQueuePolicyWildcardActionRule.py
+++ b/cfripper/rules/SQSQueuePolicyWildcardActionRule.py
@@ -22,7 +22,7 @@ class SQSQueuePolicyWildcardActionRule(Rule):
     REASON = "SQS Queue policy {} should not allow * action"
     MONITOR_MODE = False
 
-    def invoke(self, resources):
+    def invoke(self, resources, parameters):
         for resource in resources.get("AWS::SQS::QueuePolicy", []):
             if resource.policy_document.wildcard_allowed_actions(pattern=r"^(\w*:){0,1}\*$"):
                 self.add_failure(

--- a/cfripper/rules/SecurityGroupIngressOpenToWorld.py
+++ b/cfripper/rules/SecurityGroupIngressOpenToWorld.py
@@ -19,7 +19,7 @@ from cfripper.rules.SecurityGroupOpenToWorldRule import SecurityGroupOpenToWorld
 
 class SecurityGroupIngressOpenToWorld(SecurityGroupOpenToWorldRule):
 
-    def invoke(self, resources):
+    def invoke(self, resources, parameters):
         for resource in resources.get("AWS::EC2::SecurityGroupIngress", []):
             self.process_resource(resource.logical_id, resource)
 

--- a/cfripper/rules/SecurityGroupMissingEgressRule.py
+++ b/cfripper/rules/SecurityGroupMissingEgressRule.py
@@ -22,7 +22,7 @@ class SecurityGroupMissingEgressRule(Rule):
     REASON = "Missing egress rule in {} means all traffic is allowed outbound. Make this explicit if it is desired configuration"
     MONITOR_MODE = True
 
-    def invoke(self, resources):
+    def invoke(self, resources, parameters):
         for resource in resources.get("AWS::EC2::SecurityGroup", []):
             if not resource.security_group_egress:
                 self.add_failure(

--- a/cfripper/rules/SecurityGroupOpenToWorldRule.py
+++ b/cfripper/rules/SecurityGroupOpenToWorldRule.py
@@ -22,7 +22,7 @@ logger = get_logger()
 
 class SecurityGroupOpenToWorldRule(Rule):
 
-    def invoke(self, resources):
+    def invoke(self, resources, parameters):
         rs = resources.get("AWS::EC2::SecurityGroup", [])
         for resource in rs:
             self.process_resource(resource.logical_id, resource)

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ dev_requires = [
 
 setup(
     name='cfripper',
-    version='0.3.3',
+    version='0.4.0',
     author='Skyscanner Product Security',
     author_email='security@skyscanner.net',
     long_description=long_description,

--- a/tests/test_cross_account.py
+++ b/tests/test_cross_account.py
@@ -67,7 +67,7 @@ class TestCrossAccountTrustRule:
         result = Result()
         rule = CrossAccountTrustRule(None, result)
 
-        rule.invoke(template.resources)
+        rule.invoke(template.resources, template.parameters)
 
         assert result.valid
         assert len(result.failed_rules) == 0

--- a/tests/test_rules_iam_roles_overprivileged.py
+++ b/tests/test_rules_iam_roles_overprivileged.py
@@ -57,7 +57,7 @@ def test_with_valid_role_inline_policy():
 
     rule.check_managed_policies = Mock()
 
-    rule.invoke(resource)
+    rule.invoke(resource, [])
     rule.check_managed_policies.assert_called()
 
     assert result.valid
@@ -98,7 +98,7 @@ def test_with_invalid_role_inline_policy():
     rule = IAMRolesOverprivilegedRule(None, result)
     rule.check_managed_policies = Mock()
     resources = pycfmodel.parse(role_props).resources
-    rule.invoke(resources)
+    rule.invoke(resources, [])
     rule.check_managed_policies.assert_called()
 
     assert not result.valid
@@ -142,7 +142,7 @@ def test_with_invalid_role_inline_policy_resource_as_array():
     rule = IAMRolesOverprivilegedRule(None, result)
     rule.check_managed_policies = Mock()
     resources = pycfmodel.parse(role_props).resources
-    rule.invoke(resources)
+    rule.invoke(resources, [])
     rule.check_managed_policies.assert_called()
 
     assert not result.valid
@@ -170,7 +170,7 @@ def test_with_valid_role_managed_policy():
     rule = IAMRolesOverprivilegedRule(None, result)
     rule.check_inline_policies = Mock()
     resources = pycfmodel.parse(role_props).resources
-    rule.invoke(resources)
+    rule.invoke(resources, [])
     rule.check_inline_policies.assert_called()
 
     assert result.valid
@@ -196,7 +196,7 @@ def test_with_invalid_role_managed_policy():
     result = Result()
     rule = IAMRolesOverprivilegedRule(None, result)
     resources = pycfmodel.parse(role_props).resources
-    rule.invoke(resources)
+    rule.invoke(resources, [])
 
     assert not result.valid
     assert result.failed_rules[0]['reason'] == 'Role RootRole has forbidden Managed Policy arn:aws:iam::aws:policy/AdministratorAccess'
@@ -255,7 +255,7 @@ def test_with_invalid_role_inline_policy_fn_if():
     rule = IAMRolesOverprivilegedRule(None, result)
     rule.check_managed_policies = Mock()
     resources = pycfmodel.parse(role_props).resources
-    rule.invoke(resources)
+    rule.invoke(resources, [])
     rule.check_managed_policies.assert_called()
 
     assert not result.valid

--- a/tests/test_rules_s3_bucket_wildcard_action.py
+++ b/tests/test_rules_s3_bucket_wildcard_action.py
@@ -35,7 +35,7 @@ class TestS3BucketPolicyWildcardActionRule:
         result = Result()
         rule = S3BucketPolicyWildcardActionRule(None, result)
 
-        rule.invoke(template.resources)
+        rule.invoke(template.resources, template.parameters)
 
         assert not result.valid
         assert len(result.failed_rules) == 2

--- a/tests/test_rules_s3_read_plus_list.py
+++ b/tests/test_rules_s3_read_plus_list.py
@@ -35,7 +35,7 @@ class TestS3BucketPublicReadAclAndListStatementRule:
         result = Result()
         rule = S3BucketPublicReadAclAndListStatementRule(None, result)
 
-        rule.invoke(template.resources)
+        rule.invoke(template.resources, template.parameters)
 
         assert result.valid
         assert len(result.failed_rules) == 0

--- a/tests/test_rules_security_group_open_to_world.py
+++ b/tests/test_rules_security_group_open_to_world.py
@@ -43,7 +43,7 @@ class TestSecurityGroupOpenToWorldRule:
         result = Result()
         rule = SecurityGroupOpenToWorldRule(None, result)
         resources = parse(role_props).resources
-        rule.invoke(resources)
+        rule.invoke(resources, [])
 
         assert not result.valid
         assert result.failed_rules[0]['reason'] == 'Port 22 open to the world in security group "RootRole"'
@@ -71,7 +71,7 @@ class TestSecurityGroupOpenToWorldRule:
         result = Result()
         rule = SecurityGroupOpenToWorldRule(None, result)
         resources = parse(role_props).resources
-        rule.invoke(resources)
+        rule.invoke(resources, [])
 
         assert result.valid
         assert len(result.failed_rules) == 0
@@ -98,7 +98,7 @@ class TestSecurityGroupOpenToWorldRule:
         result = Result()
         rule = SecurityGroupOpenToWorldRule(None, result)
         resources = parse(role_props).resources
-        rule.invoke(resources)
+        rule.invoke(resources, [])
 
         assert result.valid
         assert len(result.failed_rules) == 0
@@ -125,7 +125,7 @@ class TestSecurityGroupOpenToWorldRule:
         result = Result()
         rule = SecurityGroupOpenToWorldRule(None, result)
         resources = parse(role_props).resources
-        rule.invoke(resources)
+        rule.invoke(resources, [])
 
         assert result.valid
         assert len(result.failed_rules) == 0
@@ -152,7 +152,7 @@ class TestSecurityGroupOpenToWorldRule:
         result = Result()
         rule = SecurityGroupOpenToWorldRule(None, result)
         resources = parse(role_props).resources
-        rule.invoke(resources)
+        rule.invoke(resources, [])
 
         assert result.failed_rules[0]['reason'] == 'Port 22 open to the world in security group "RootRole"'
         assert result.failed_rules[0]['rule'] == 'SecurityGroupOpenToWorldRule'
@@ -179,7 +179,7 @@ class TestSecurityGroupOpenToWorldRule:
         result = Result()
         rule = SecurityGroupOpenToWorldRule(None, result)
         resources = parse(role_props).resources
-        rule.invoke(resources)
+        rule.invoke(resources, [])
 
         assert result.failed_rules[0]['reason'] == 'Ports 0 - 100 open in Security Group RootRole'
         assert result.failed_rules[0]['rule'] == 'SecurityGroupOpenToWorldRule'
@@ -211,7 +211,7 @@ class TestSecurityGroupOpenToWorldRule:
         result = Result()
         rule = SecurityGroupOpenToWorldRule(None, result)
         resources = parse(role_props).resources
-        rule.invoke(resources)
+        rule.invoke(resources, [])
 
         assert result.failed_rules[0]['reason'] == 'Port 9090 open to the world in security group "RootRole"'
         assert result.failed_rules[0]['rule'] == 'SecurityGroupOpenToWorldRule'
@@ -241,7 +241,7 @@ class TestSecurityGroupOpenToWorldRule:
         result = Result()
         rule = SecurityGroupOpenToWorldRule(None, result)
         resources = parse(role_props).resources
-        rule.invoke(resources)
+        rule.invoke(resources, [])
 
         assert result.valid
         assert len(result.failed_rules) == 0

--- a/tests/test_rules_sqs_policy_public.py
+++ b/tests/test_rules_sqs_policy_public.py
@@ -36,7 +36,7 @@ class TestSQSQueuePolicyPublicRule:
         result = Result()
         rule = SQSQueuePolicyPublicRule(None, result)
 
-        rule.invoke(template.resources)
+        rule.invoke(template.resources, template.parameters)
 
         assert not result.valid
         assert len(result.failed_rules) == 4

--- a/tests/test_rules_sqs_policy_wildcard.py
+++ b/tests/test_rules_sqs_policy_wildcard.py
@@ -36,7 +36,7 @@ class TestSQSQueuePolicyWildcardActionRule:
         result = Result()
         rule = SQSQueuePolicyWildcardActionRule(None, result)
 
-        rule.invoke(template.resources)
+        rule.invoke(template.resources, template.parameters)
 
         assert not result.valid
         assert len(result.failed_rules) == 4

--- a/tests/test_s3_cross_account.py
+++ b/tests/test_s3_cross_account.py
@@ -37,7 +37,7 @@ class TestS3CrossAccountTrustRule:
         result = Result()
         rule = S3CrossAccountTrustRule(None, result)
 
-        rule.invoke(template.resources)
+        rule.invoke(template.resources, template.parameters)
 
         assert result.valid
         assert len(result.failed_rules) == 0
@@ -62,7 +62,7 @@ class TestS3CrossAccountTrustRuleWithNormalAccess:
         result = Result()
         rule = S3CrossAccountTrustRule(None, result)
 
-        rule.invoke(template.resources)
+        rule.invoke(template.resources, template.parameters)
 
         assert result.valid
         assert len(result.failed_rules) == 0


### PR DESCRIPTION
There are cases in which rules need to access the parameters.
This change starts passing the parameters from the pycfmodel to rule invokation.