### PR TITLE
Update method to get whitelisted rules for a stack

### DIFF
--- a/cfripper/config/config.py
+++ b/cfripper/config/config.py
@@ -110,10 +110,9 @@ class Config:
         self.stack_whitelist = stack_whitelist if stack_whitelist is not None else default_stack_whitelist
 
         if self.stack_name:
-            exemption_list = self.get_stack_exemption_list()
-
+            whitelisted_rules = self.get_whitelisted_rules()
             # set difference to get a list of allowed rules to be ran for this stack
-            self.rules = list(set(self.rules) - set(exemption_list))
+            self.rules = list(set(self.rules) - set(whitelisted_rules))
 
         self.allowed_world_open_ports = list(self.DEFAULT_ALLOWED_WORLD_OPEN_PORTS)
 
@@ -132,9 +131,10 @@ class Config:
 
         return allowed_resources
 
-    def get_stack_exemption_list(self) -> List[str]:
+    def get_whitelisted_rules(self) -> List[str]:
+        whitelisted_rules = []
         for k, v in self.stack_whitelist.items():
             if re.match(k, self.stack_name):
-                return v
+                whitelisted_rules += v
 
-        return []
+        return whitelisted_rules

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -104,3 +104,34 @@ class TestMainHandler:
             if r.RULE_MODE not in ["BLOCKING", "MONITOR", "DEBUG"]:
                 assert False
         assert True
+
+    def test_stack_whitelist_joins_all_whitelisted_matching_stack_names(self):
+        mock_whitelist = {
+            "stackname": [
+                "S3CrossAccountTrustRule",
+            ],
+            "notstackname": [
+                "IAMRolesOverprivilegedRule",
+            ],
+            "stackname_withmorethings": [
+                "CrossAccountTrustRule",
+                "ManagedPolicyOnUserRule",
+            ]
+
+        }
+
+        config = Config(
+            project_name="project_mock",
+            service_name="service_mock",
+            stack_name="stackname_withmorethings",
+            stack_whitelist=mock_whitelist,
+            rules=DEFAULT_RULES.keys(),
+        )
+
+        whitelisted_rules = config.get_whitelisted_rules()
+
+        assert set(whitelisted_rules) == {
+            "CrossAccountTrustRule",
+            "ManagedPolicyOnUserRule",
+            "S3CrossAccountTrustRule",
+        }


### PR DESCRIPTION
## Context
The current `get_stack_exemption_list` method returns right after finding the first matching expression in the whitelist, this causes a bug where the following whitelist wouldn't work:
```
stack_whitelist = {
    "stack*": [
        "Rule1",
        "Rule2",
    ],
    "stackname": [
        "Rule3",
        "Rule4",
    ],
```
Because the stack with name `stackname` would only be whitelisted for Rule1 and RUle2, not Rule3 and Rule4. This change fixes this issue and updates the variable names for clarity.

## Changes
- Renamed `get_exemption_list` to `get_whitelisted_rules`
- Fixed `get_whitelisted_rules` to get all whitelists that match the stack name instead of the first one
- Added test to check that the functionality works as expected.