### PR TITLE
Move classes and constants to separate files

### DIFF
--- a/cfripper/config/config.py
+++ b/cfripper/config/config.py
@@ -46,7 +46,8 @@ class Config:
         "iam:Create",
         "iam:Delete",
         "iam:Put",
-        "iam:Update" "iam:Remove",
+        "iam:Update",
+        "iam:Remove",
         # pword / MFA STUFF
         "iam:ChangePassword",
         "iam:ResyncMFADevice",

--- a/cfripper/model/enums.py
+++ b/cfripper/model/enums.py
@@ -1,0 +1,15 @@
+from enum import Enum
+
+
+class RuleMode(str, Enum):
+    # Rule modes
+    BLOCKING = "BLOCKING"
+    MONITOR = "MONITOR"
+    DEBUG = "DEBUG"
+
+
+class RuleRisk(str, Enum):
+    # Rule risk severity
+    LOW = "LOW"
+    MEDIUM = "MEDIUM"
+    HIGH = "HIGH"

--- a/cfripper/model/result.py
+++ b/cfripper/model/result.py
@@ -12,10 +12,12 @@ under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from cfripper.model.rule_processor import Rule
+from typing import Dict
+
+from cfripper.model.enums import RuleMode
 
 
-class Result(object):
+class Result:
     """An object to represent scan results."""
 
     def __init__(self):
@@ -25,15 +27,29 @@ class Result(object):
         self.failed_monitored_rules = []
         self.warnings = []
 
-    def add_failure(self, rule, reason, rule_mode, risk_value):
-        if rule_mode is not Rule.BLOCKING:
-            self.add_failed_monitored_rule(rule, reason, rule_mode, risk_value)
+    def add_failure(
+        self,
+        rule: str,
+        reason: str,
+        rule_mode: str,
+        risk_value: str,
+    ):
+
+        failure = {
+            "rule": rule,
+            "reason": reason,
+            "rule_mode": rule_mode,
+            "risk_value": risk_value,
+        }
+
+        if rule_mode is not RuleMode.BLOCKING:
+            self.add_failure_monitored_rule(failure=failure)
             return
 
         if self.valid:
             self.valid = False
 
-        self.failed_rules.append({"rule": rule, "reason": reason, "rule_mode": rule_mode, "risk_value": risk_value})
+        self.add_failure_blocking_rule(failure=failure)
 
     def add_exception(self, ex):
         self.exceptions.append(ex)
@@ -41,7 +57,8 @@ class Result(object):
     def add_warning(self, warning):
         self.warnings.append(warning)
 
-    def add_failed_monitored_rule(self, rule, reason, rule_mode, risk_value):
-        self.failed_monitored_rules.append(
-            {"rule": rule, "reason": reason, "rule_mode": rule_mode, "risk_value": risk_value}
-        )
+    def add_failure_monitored_rule(self, failure: Dict):
+        self.failed_monitored_rules.append(failure)
+
+    def add_failure_blocking_rule(self, failure: Dict):
+        self.failed_rules.append(failure)

--- a/cfripper/model/rule.py
+++ b/cfripper/model/rule.py
@@ -1,0 +1,31 @@
+from abc import ABC, abstractmethod
+from typing import Optional
+
+from cfripper.config.config import Config
+from cfripper.model.enums import RuleMode, RuleRisk
+from cfripper.model.result import Result
+
+
+class Rule(ABC):
+    RULE_MODE = RuleMode.BLOCKING
+    RISK_VALUE = RuleRisk.MEDIUM
+
+    def __init__(self, config: Optional[Config], result: Result):
+        self._config = config if config else Config()
+        self._result = result
+
+    @abstractmethod
+    def invoke(self, resources, parameters):
+        pass
+
+    def add_failure(self, rule: str, reason: str):
+
+        self._result.add_failure(
+            rule=rule,
+            reason=reason,
+            rule_mode=self.RULE_MODE,
+            risk_value=self.RISK_VALUE,
+        )
+
+    def add_warning(self, warning):
+        self._result.add_warning(warning)

--- a/cfripper/model/rule_processor.py
+++ b/cfripper/model/rule_processor.py
@@ -13,39 +13,13 @@ CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
 import logging
-from abc import ABC, abstractmethod
 
 import pycfmodel
 
-from cfripper.config.config import Config
+from cfripper.model.enums import RuleMode
 from cfripper.model.managed_policy_transformer import ManagedPolicyTransformer
 
 logger = logging.getLogger(__file__)
-
-
-class Rule(ABC):
-    BLOCKING = "BLOCKING"
-    MONITOR = "MONITOR"
-    DEBUG = "DEBUG"
-    LOW = "LOW"
-    MEDIUM = "MEDIUM"
-    HIGH = "HIGH"
-    RULE_MODE = BLOCKING
-    RISK_VALUE = MEDIUM
-
-    def __init__(self, config, result):
-        self._config = config if config else Config()
-        self._result = result
-
-    @abstractmethod
-    def invoke(self, resources, parameters):
-        pass
-
-    def add_failure(self, rule, reason):
-        self._result.add_failure(rule, reason, self.RULE_MODE, self.RISK_VALUE)
-
-    def add_warning(self, warning):
-        self._result.add_warning(warning)
 
 
 class RuleProcessor:
@@ -81,4 +55,4 @@ class RuleProcessor:
 
     @staticmethod
     def remove_debug_rules(rules):
-        return [rule for rule in rules if rule["rule_mode"] != Rule.DEBUG]
+        return [rule for rule in rules if rule["rule_mode"] != RuleMode.DEBUG]

--- a/cfripper/rules/CloudFormationAuthenticationRule.py
+++ b/cfripper/rules/CloudFormationAuthenticationRule.py
@@ -14,7 +14,7 @@ specific language governing permissions and limitations under the License.
 """
 
 
-from cfripper.model.rule_processor import Rule
+from cfripper.model.rule import Rule
 
 
 """

--- a/cfripper/rules/CrossAccountTrustRule.py
+++ b/cfripper/rules/CrossAccountTrustRule.py
@@ -15,7 +15,7 @@ specific language governing permissions and limitations under the License.
 import logging
 import re
 from cfripper.config.regex import REGEX_CROSS_ACCOUNT_ROOT
-from cfripper.model.rule_processor import Rule
+from cfripper.model.rule import Rule
 
 logger = logging.getLogger(__file__)
 

--- a/cfripper/rules/EBSVolumeHasSSERule.py
+++ b/cfripper/rules/EBSVolumeHasSSERule.py
@@ -12,15 +12,14 @@ under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-
-
-from cfripper.model.rule_processor import Rule
+from cfripper.model.enums import RuleMode
+from cfripper.model.rule import Rule
 
 
 class EBSVolumeHasSSERule(Rule):
 
     REASON = "EBS volume {} should have server-side encryption enabled"
-    RULE_MODE = Rule.MONITOR
+    RULE_MODE = RuleMode.MONITOR
 
     def invoke(self, resources, parameters):
         for resource in resources.get("AWS::EC2::Volume", []):

--- a/cfripper/rules/FullWildcardPrincipal.py
+++ b/cfripper/rules/FullWildcardPrincipal.py
@@ -14,7 +14,7 @@ specific language governing permissions and limitations under the License.
 """
 
 from cfripper.config.regex import REGEX_FULL_WILDCARD_PRINCIPAL
-from cfripper.model.rule_processor import Rule
+from cfripper.model.enums import RuleMode, RuleRisk
 from cfripper.rules.WildcardPrincipal import GenericWildcardPrincipal
 
 
@@ -22,7 +22,7 @@ class FullWildcardPrincipal(GenericWildcardPrincipal):
 
     REASON_WILCARD_PRINCIPAL = "{} should not allow wildcards in principals (principal: '{}')"
 
-    RULE_MODE = Rule.BLOCKING
-    RISK_VALUE = Rule.HIGH
+    RULE_MODE = RuleMode.BLOCKING
+    RISK_VALUE = RuleRisk.HIGH
 
     FULL_REGEX = REGEX_FULL_WILDCARD_PRINCIPAL

--- a/cfripper/rules/HardcodedRDSPasswordRule.py
+++ b/cfripper/rules/HardcodedRDSPasswordRule.py
@@ -14,7 +14,7 @@ specific language governing permissions and limitations under the License.
 """
 
 
-from cfripper.model.rule_processor import Rule
+from cfripper.model.rule import Rule
 
 
 class HardcodedRDSPasswordRule(Rule):

--- a/cfripper/rules/IAMManagedPolicyWildcardActionRule.py
+++ b/cfripper/rules/IAMManagedPolicyWildcardActionRule.py
@@ -15,7 +15,7 @@ specific language governing permissions and limitations under the License.
 
 
 from cfripper.config.regex import REGEX_WILDCARD_POLICY_ACTION
-from cfripper.model.rule_processor import Rule
+from cfripper.model.rule import Rule
 
 
 class IAMManagedPolicyWildcardActionRule(Rule):

--- a/cfripper/rules/IAMRoleWildcardActionOnPermissionsPolicyRule.py
+++ b/cfripper/rules/IAMRoleWildcardActionOnPermissionsPolicyRule.py
@@ -15,7 +15,7 @@ specific language governing permissions and limitations under the License.
 
 
 from cfripper.config.regex import REGEX_WILDCARD_POLICY_ACTION
-from cfripper.model.rule_processor import Rule
+from cfripper.model.rule import Rule
 
 
 class IAMRoleWildcardActionOnPermissionsPolicyRule(Rule):

--- a/cfripper/rules/IAMRoleWildcardActionOnTrustPolicyRule.py
+++ b/cfripper/rules/IAMRoleWildcardActionOnTrustPolicyRule.py
@@ -15,7 +15,7 @@ specific language governing permissions and limitations under the License.
 
 
 from cfripper.config.regex import REGEX_WILDCARD_POLICY_ACTION
-from cfripper.model.rule_processor import Rule
+from cfripper.model.rule import Rule
 
 
 class IAMRoleWildcardActionOnTrustPolicyRule(Rule):

--- a/cfripper/rules/IAMRolesOverprivilegedRule.py
+++ b/cfripper/rules/IAMRolesOverprivilegedRule.py
@@ -14,7 +14,7 @@ specific language governing permissions and limitations under the License.
 """
 import logging
 
-from cfripper.model.rule_processor import Rule
+from cfripper.model.rule import Rule
 
 logger = logging.getLogger(__file__)
 

--- a/cfripper/rules/KMSKeyWildcardPrincipal.py
+++ b/cfripper/rules/KMSKeyWildcardPrincipal.py
@@ -14,7 +14,7 @@ specific language governing permissions and limitations under the License.
 """
 
 
-from cfripper.model.rule_processor import Rule
+from cfripper.model.rule import Rule
 
 
 class KMSKeyWildcardPrincipal(Rule):

--- a/cfripper/rules/ManagedPolicyOnUserRule.py
+++ b/cfripper/rules/ManagedPolicyOnUserRule.py
@@ -12,15 +12,14 @@ under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-
-
-from cfripper.model.rule_processor import Rule
+from cfripper.model.enums import RuleMode
+from cfripper.model.rule import Rule
 
 
 class ManagedPolicyOnUserRule(Rule):
 
     REASON = "IAM managed policy {} should not apply directly to users. Should be on group"
-    RULE_MODE = Rule.MONITOR
+    RULE_MODE = RuleMode.MONITOR
 
     def invoke(self, resources, parameters):
         for resource in resources.get("AWS::IAM::ManagedPolicy", []):

--- a/cfripper/rules/PartialWildcardPrincipal.py
+++ b/cfripper/rules/PartialWildcardPrincipal.py
@@ -12,8 +12,7 @@ under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-
-from cfripper.model.rule_processor import Rule
+from cfripper.model.enums import RuleMode, RuleRisk
 from cfripper.rules.WildcardPrincipal import GenericWildcardPrincipal
 
 
@@ -21,8 +20,8 @@ class PartialWildcardPrincipal(GenericWildcardPrincipal):
 
     REASON_WILCARD_PRINCIPAL = "{} should not allow wildcard in principals or account-wide principals (principal: '{}')"
 
-    RULE_MODE = Rule.MONITOR
-    RISK_VALUE = Rule.MEDIUM
+    RULE_MODE = RuleMode.MONITOR
+    RISK_VALUE = RuleRisk.MEDIUM
     """
     Will catch:
 

--- a/cfripper/rules/PolicyOnUserRule.py
+++ b/cfripper/rules/PolicyOnUserRule.py
@@ -12,15 +12,14 @@ under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-
-
-from cfripper.model.rule_processor import Rule
+from cfripper.model.enums import RuleMode
+from cfripper.model.rule import Rule
 
 
 class PolicyOnUserRule(Rule):
 
     REASON = "IAM policy {} should not apply directly to users. Should be on group"
-    RULE_MODE = Rule.MONITOR
+    RULE_MODE = RuleMode.MONITOR
 
     def invoke(self, resources, parameters):
         for resource in resources.get("AWS::IAM::Policy", []):

--- a/cfripper/rules/PrivilegeEscalationRule.py
+++ b/cfripper/rules/PrivilegeEscalationRule.py
@@ -14,7 +14,7 @@ specific language governing permissions and limitations under the License.
 """
 
 
-from cfripper.model.rule_processor import Rule
+from cfripper.model.rule import Rule
 
 
 class PrivilegeEscalationRule(Rule):

--- a/cfripper/rules/S3BucketPolicyPrincipalRule.py
+++ b/cfripper/rules/S3BucketPolicyPrincipalRule.py
@@ -14,7 +14,9 @@ specific language governing permissions and limitations under the License.
 """
 import logging
 import re
-from cfripper.model.rule_processor import Rule
+
+from cfripper.model.enums import RuleMode, RuleRisk
+from cfripper.model.rule import Rule
 
 logger = logging.getLogger(__file__)
 
@@ -22,8 +24,8 @@ logger = logging.getLogger(__file__)
 class S3BucketPolicyPrincipalRule(Rule):
 
     REASON = "S3 Bucket {} policy has non-whitelisted principals {}"
-    RULE_MODE = Rule.BLOCKING
-    RISK_VALUE = Rule.HIGH
+    RULE_MODE = RuleMode.BLOCKING
+    RISK_VALUE = RuleRisk.HIGH
     PATTERN = r"arn:aws:iam::(\d*):.*"
 
     def invoke(self, resources, parameters):

--- a/cfripper/rules/S3BucketPolicyWildcardActionRule.py
+++ b/cfripper/rules/S3BucketPolicyWildcardActionRule.py
@@ -14,7 +14,7 @@ specific language governing permissions and limitations under the License.
 """
 
 
-from cfripper.model.rule_processor import Rule
+from cfripper.model.rule import Rule
 
 
 class S3BucketPolicyWildcardActionRule(Rule):

--- a/cfripper/rules/S3BucketPublicReadAclAndListStatementRule.py
+++ b/cfripper/rules/S3BucketPublicReadAclAndListStatementRule.py
@@ -14,7 +14,8 @@ specific language governing permissions and limitations under the License.
 """
 import logging
 
-from cfripper.model.rule_processor import Rule
+from cfripper.model.enums import RuleMode
+from cfripper.model.rule import Rule
 
 logger = logging.getLogger(__file__)
 
@@ -22,7 +23,7 @@ logger = logging.getLogger(__file__)
 class S3BucketPublicReadAclAndListStatementRule(Rule):
 
     REASON = "S3 Bucket {} should not have a public read acl and list bucket statement"
-    RULE_MODE = Rule.DEBUG
+    RULE_MODE = RuleMode.DEBUG
 
     def invoke(self, resources, parameters):
         # Get all bucket policies and filter to get the ones that allow list actions

--- a/cfripper/rules/S3BucketPublicReadWriteAclRule.py
+++ b/cfripper/rules/S3BucketPublicReadWriteAclRule.py
@@ -14,7 +14,8 @@ specific language governing permissions and limitations under the License.
 """
 import logging
 
-from cfripper.model.rule_processor import Rule
+from cfripper.model.enums import RuleRisk
+from cfripper.model.rule import Rule
 
 logger = logging.getLogger(__file__)
 
@@ -22,7 +23,7 @@ logger = logging.getLogger(__file__)
 class S3BucketPublicReadWriteAclRule(Rule):
 
     REASON = "S3 Bucket {} should not have a public read-write acl"
-    RISK_VALUE = Rule.HIGH
+    RISK_VALUE = RuleRisk.HIGH
 
     def invoke(self, resources, parameters):
         for resource in resources.get("AWS::S3::Bucket", []):

--- a/cfripper/rules/S3CrossAccountTrustRule.py
+++ b/cfripper/rules/S3CrossAccountTrustRule.py
@@ -14,7 +14,7 @@ specific language governing permissions and limitations under the License.
 """
 import logging
 
-from cfripper.model.rule_processor import Rule
+from cfripper.model.rule import Rule
 
 logger = logging.getLogger(__file__)
 

--- a/cfripper/rules/SNSTopicPolicyNotPrincipalRule.py
+++ b/cfripper/rules/SNSTopicPolicyNotPrincipalRule.py
@@ -12,14 +12,13 @@ under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-
-
-from cfripper.model.rule_processor import Rule
+from cfripper.model.enums import RuleMode
+from cfripper.model.rule import Rule
 
 
 class SNSTopicPolicyNotPrincipalRule(Rule):
     REASON = "SNS Topic {} policy should not allow Allow+NotPrincipal"
-    RULE_MODE = Rule.MONITOR
+    RULE_MODE = RuleMode.MONITOR
 
     def invoke(self, resources, parameters):
         for resource in resources.get("AWS::SNS::TopicPolicy", []):

--- a/cfripper/rules/SQSQueuePolicyNotPrincipalRule.py
+++ b/cfripper/rules/SQSQueuePolicyNotPrincipalRule.py
@@ -12,14 +12,13 @@ under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-
-
-from cfripper.model.rule_processor import Rule
+from cfripper.model.enums import RuleMode
+from cfripper.model.rule import Rule
 
 
 class SQSQueuePolicyNotPrincipalRule(Rule):
     REASON = "SQS Queue {} policy should not allow Allow+NotPrincipal"
-    RULE_MODE = Rule.MONITOR
+    RULE_MODE = RuleMode.MONITOR
 
     def invoke(self, resources, parameters):
         for resource in resources.get("AWS::SQS::QueuePolicy", []):

--- a/cfripper/rules/SQSQueuePolicyPublicRule.py
+++ b/cfripper/rules/SQSQueuePolicyPublicRule.py
@@ -12,15 +12,14 @@ under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-
-
-from cfripper.model.rule_processor import Rule
+from cfripper.model.enums import RuleRisk
+from cfripper.model.rule import Rule
 
 
 class SQSQueuePolicyPublicRule(Rule):
 
     REASON = "SQS Queue policy {} should not be public"
-    RISK_VALUE = Rule.HIGH
+    RISK_VALUE = RuleRisk.HIGH
 
     def invoke(self, resources, parameters):
         for resource in resources.get("AWS::SQS::QueuePolicy", []):

--- a/cfripper/rules/SQSQueuePolicyWildcardActionRule.py
+++ b/cfripper/rules/SQSQueuePolicyWildcardActionRule.py
@@ -14,7 +14,7 @@ specific language governing permissions and limitations under the License.
 """
 
 
-from cfripper.model.rule_processor import Rule
+from cfripper.model.rule import Rule
 
 
 class SQSQueuePolicyWildcardActionRule(Rule):

--- a/cfripper/rules/SecurityGroupMissingEgressRule.py
+++ b/cfripper/rules/SecurityGroupMissingEgressRule.py
@@ -12,9 +12,8 @@ under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-
-
-from cfripper.model.rule_processor import Rule
+from cfripper.model.enums import RuleMode
+from cfripper.model.rule import Rule
 
 
 class SecurityGroupMissingEgressRule(Rule):
@@ -23,7 +22,7 @@ class SecurityGroupMissingEgressRule(Rule):
         "Missing egress rule in {} means all traffic is allowed outbound. "
         "Make this explicit if it is desired configuration"
     )
-    RULE_MODE = Rule.MONITOR
+    RULE_MODE = RuleMode.MONITOR
 
     def invoke(self, resources, parameters):
         for resource in resources.get("AWS::EC2::SecurityGroup", []):

--- a/cfripper/rules/SecurityGroupOpenToWorldRule.py
+++ b/cfripper/rules/SecurityGroupOpenToWorldRule.py
@@ -14,7 +14,7 @@ specific language governing permissions and limitations under the License.
 """
 import logging
 
-from cfripper.model.rule_processor import Rule
+from cfripper.model.rule import Rule
 
 logger = logging.getLogger(__file__)
 

--- a/cfripper/rules/WildcardPrincipal.py
+++ b/cfripper/rules/WildcardPrincipal.py
@@ -15,7 +15,8 @@ specific language governing permissions and limitations under the License.
 import logging
 import re
 
-from cfripper.model.rule_processor import Rule
+from cfripper.model.enums import RuleMode
+from cfripper.model.rule import Rule
 
 logger = logging.getLogger(__file__)
 
@@ -26,7 +27,7 @@ class GenericWildcardPrincipal(Rule):
 
     REASON_WILCARD_PRINCIPAL = "{} should not allow wildcard in principals or account-wide principals (principal: '{}')"
     REASON_NOT_ALLOWED_PRINCIPAL = "{} contains an unknown principal: {}"
-    RULE_MODE = Rule.MONITOR
+    RULE_MODE = RuleMode.MONITOR
     IAM_PATTERN = r"arn:aws:iam::(\d*|\*):.*"
 
     FULL_REGEX = r"^((\w*:){0,1}\*|arn:aws:iam::(\d*|\*):.*)$"

--- a/tests/test_rule_processor.py
+++ b/tests/test_rule_processor.py
@@ -15,7 +15,8 @@ specific language governing permissions and limitations under the License.
 
 
 from unittest.mock import Mock
-from cfripper.model.rule_processor import Rule
+
+from cfripper.model.enums import RuleMode, RuleRisk
 from cfripper.model.rule_processor import RuleProcessor
 
 
@@ -98,14 +99,14 @@ class TestRuleProcessor:
 
     def test_remove_debug_rules(self):
         original_failed_monitored_rules = [
-            {"rule": "a", "reason": "something", "rule_mode": Rule.MONITOR, "risk_value": Rule.HIGH},
-            {"rule": "b", "reason": "something", "rule_mode": Rule.DEBUG, "risk_value": Rule.MEDIUM},
-            {"rule": "c", "reason": "something", "rule_mode": Rule.MONITOR, "risk_value": Rule.LOW},
+            {"rule": "a", "reason": "something", "rule_mode": RuleMode.MONITOR, "risk_value": RuleRisk.HIGH},
+            {"rule": "b", "reason": "something", "rule_mode": RuleMode.DEBUG, "risk_value": RuleRisk.MEDIUM},
+            {"rule": "c", "reason": "something", "rule_mode": RuleMode.MONITOR, "risk_value": RuleRisk.LOW},
         ]
 
         list_with_no_debug_rules = [
-            {"rule": "a", "reason": "something", "rule_mode": Rule.MONITOR, "risk_value": Rule.HIGH},
-            {"rule": "c", "reason": "something", "rule_mode": Rule.MONITOR, "risk_value": Rule.LOW},
+            {"rule": "a", "reason": "something", "rule_mode": RuleMode.MONITOR, "risk_value": RuleRisk.HIGH},
+            {"rule": "c", "reason": "something", "rule_mode": RuleMode.MONITOR, "risk_value": RuleRisk.LOW},
         ]
 
         processed_list = RuleProcessor.remove_debug_rules(rules=original_failed_monitored_rules)

--- a/tests/test_rules_s3_read_plus_list.py
+++ b/tests/test_rules_s3_read_plus_list.py
@@ -17,8 +17,9 @@ specific language governing permissions and limitations under the License.
 import pytest
 import os
 import pycfmodel
+
+from cfripper.model.enums import RuleMode
 from cfripper.model.result import Result
-from cfripper.model.rule_processor import Rule
 from cfripper.model.utils import convert_json_or_yaml_to_dict
 from cfripper.rules.S3BucketPublicReadAclAndListStatementRule import S3BucketPublicReadAclAndListStatementRule
 
@@ -44,4 +45,4 @@ class TestS3BucketPublicReadAclAndListStatementRule:
             result.failed_monitored_rules[0]["reason"]
             == "S3 Bucket S3Bucket should not have a public read acl and list bucket statement"
         )
-        assert result.failed_monitored_rules[0]["rule_mode"] == Rule.DEBUG
+        assert result.failed_monitored_rules[0]["rule_mode"] == RuleMode.DEBUG

--- a/tests/test_rules_sqs_policy_public.py
+++ b/tests/test_rules_sqs_policy_public.py
@@ -18,10 +18,10 @@ import pytest
 import os
 import pycfmodel
 
+from cfripper.model.enums import RuleRisk
 from cfripper.rules.SQSQueuePolicyPublicRule import SQSQueuePolicyPublicRule
 from cfripper.model.utils import convert_json_or_yaml_to_dict
 from cfripper.model.result import Result
-from cfripper.model.rule_processor import Rule
 
 
 class TestSQSQueuePolicyPublicRule:
@@ -45,4 +45,4 @@ class TestSQSQueuePolicyPublicRule:
         assert result.failed_rules[2]["reason"] == "SQS Queue policy QueuePolicyPublic3 should not be public"
         assert result.failed_rules[3]["reason"] == "SQS Queue policy QueuePolicyPublic4 should not be public"
 
-        assert result.failed_rules[0]["risk_value"] == Rule.HIGH
+        assert result.failed_rules[0]["risk_value"] == RuleRisk.HIGH


### PR DESCRIPTION
## Context
The `Rule` and `RuleProcessor` classes were located in the same file, this made expanding the classes more complicated and can lead to some circular dependencies in the future, same with the Rule Modes and Rule Risks, which until now were all constants in the rule class. 

## Changes
- Move RuleRisk and RuleMode enums to a separate file
- Move Rule to a separate file
- Update imports and usage of the rule constants everywhere
- No functional changes