### PR TITLE
Add resource and action to failure, use generic whitelists to remove whitelisted failures

### DIFF
--- a/cfripper/model/enums.py
+++ b/cfripper/model/enums.py
@@ -13,3 +13,10 @@ class RuleRisk(str, Enum):
     LOW = "LOW"
     MEDIUM = "MEDIUM"
     HIGH = "HIGH"
+
+
+class RuleGranularity(str, Enum):
+    # Rule
+    ACTION = "ACTION"
+    RESOURCE = "RESOURCE"
+    STACK = "STACK"

--- a/cfripper/model/result.py
+++ b/cfripper/model/result.py
@@ -33,13 +33,25 @@ class Result:
         reason: str,
         rule_mode: str,
         risk_value: str,
+        granularity: str,
+        resource_ids=None,
+        actions=None,
     ):
+
+        if resource_ids is None:
+            resource_ids = set()
+
+        if actions is None:
+            actions = set()
 
         failure = {
             "rule": rule,
             "reason": reason,
             "rule_mode": rule_mode,
             "risk_value": risk_value,
+            "resource_ids": resource_ids,
+            "actions": actions,
+            "granularity": granularity,
         }
 
         if rule_mode is not RuleMode.BLOCKING:

--- a/cfripper/model/rule.py
+++ b/cfripper/model/rule.py
@@ -22,7 +22,7 @@ class Rule(ABC):
     def add_failure(self, rule: str, reason: str, granularity=None):
 
         if granularity is None:
-            granularity = self.GRANULATIRY
+            granularity = self.GRANULARITY
 
         self._result.add_failure(
             rule=rule,

--- a/cfripper/model/rule.py
+++ b/cfripper/model/rule.py
@@ -9,7 +9,7 @@ from cfripper.model.result import Result
 class Rule(ABC):
     RULE_MODE = RuleMode.BLOCKING
     RISK_VALUE = RuleRisk.MEDIUM
-    GRANULATIRY = RuleGranularity.STACK
+    GRANULARITY = RuleGranularity.STACK
 
     def __init__(self, config: Optional[Config], result: Result):
         self._config = config if config else Config()

--- a/cfripper/model/rule.py
+++ b/cfripper/model/rule.py
@@ -2,13 +2,14 @@ from abc import ABC, abstractmethod
 from typing import Optional
 
 from cfripper.config.config import Config
-from cfripper.model.enums import RuleMode, RuleRisk
+from cfripper.model.enums import RuleMode, RuleRisk, RuleGranularity
 from cfripper.model.result import Result
 
 
 class Rule(ABC):
     RULE_MODE = RuleMode.BLOCKING
     RISK_VALUE = RuleRisk.MEDIUM
+    GRANULATIRY = RuleGranularity.STACK
 
     def __init__(self, config: Optional[Config], result: Result):
         self._config = config if config else Config()
@@ -18,13 +19,17 @@ class Rule(ABC):
     def invoke(self, resources, parameters):
         pass
 
-    def add_failure(self, rule: str, reason: str):
+    def add_failure(self, rule: str, reason: str, granularity=None):
+
+        if granularity is None:
+            granularity = self.GRANULATIRY
 
         self._result.add_failure(
             rule=rule,
             reason=reason,
             rule_mode=self.RULE_MODE,
             risk_value=self.RISK_VALUE,
+            granularity=granularity
         )
 
     def add_warning(self, warning):

--- a/cfripper/model/rule_processor.py
+++ b/cfripper/model/rule_processor.py
@@ -88,7 +88,6 @@ class RuleProcessor:
                     for whitelisted_resource_regex in config.get_whitelisted_resources(failure["rule"])
                 ])
             }
-            print(f"XXXXXX {whitelisted_resources}")
             failure["resource_ids"] = failure["resource_ids"] - whitelisted_resources
             if failure["resource_ids"]:
                 clean_failures.append(failure)

--- a/cfripper/model/rule_processor.py
+++ b/cfripper/model/rule_processor.py
@@ -13,11 +13,14 @@ CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
 import logging
+import re
 
 import pycfmodel
 
-from cfripper.model.enums import RuleMode
+from cfripper.config.config import Config
+from cfripper.model.enums import RuleMode, RuleGranularity
 from cfripper.model.managed_policy_transformer import ManagedPolicyTransformer
+from cfripper.model.result import Result
 
 logger = logging.getLogger(__file__)
 
@@ -53,6 +56,72 @@ class RuleProcessor:
                 )
                 continue
 
+        self.remove_failures_of_whitelisted_actions(config=config, result=result)
+        self.remove_failures_of_whitelisted_resources(config=config, result=result)
+
     @staticmethod
     def remove_debug_rules(rules):
         return [rule for rule in rules if rule["rule_mode"] != RuleMode.DEBUG]
+
+    @staticmethod
+    def remove_failures_of_whitelisted_resources(config: Config, result: Result):
+
+        if not result.failed_rules:
+            return
+
+        clean_failures = []
+
+        for failure in result.failed_rules:
+            if failure["granularity"] != RuleGranularity.RESOURCE:
+                clean_failures.append(failure)
+                continue
+
+            if not failure.get("resource_ids"):
+                logger.warning(f"Failure with resource granularity doesn't have resources: {failure}")
+                continue
+
+            whitelisted_resources = {
+                resource
+                for resource in failure["resource_ids"]
+                if any([
+                    re.match(whitelisted_resource_regex, resource)
+                    for whitelisted_resource_regex in config.get_whitelisted_resources(failure["rule"])
+                ])
+            }
+            print(f"XXXXXX {whitelisted_resources}")
+            failure["resource_ids"] = failure["resource_ids"] - whitelisted_resources
+            if failure["resource_ids"]:
+                clean_failures.append(failure)
+
+        result.failed_rules = clean_failures
+
+    @staticmethod
+    def remove_failures_of_whitelisted_actions(config: Config, result: Result):
+
+        if not result.failed_rules:
+            return
+
+        clean_failures = []
+
+        for failure in result.failed_rules:
+            if failure["granularity"] != RuleGranularity.ACTION:
+                clean_failures.append(failure)
+                continue
+
+            if not failure.get("actions"):
+                logger.warning(f"Failure with action granularity doesn't have actions: {failure}")
+                continue
+
+            whitelisted_actions = {
+                action
+                for action in failure["actions"]
+                if any([
+                    re.match(whitelisted_action_regex, action)
+                    for whitelisted_action_regex in config.get_whitelisted_actions(failure["rule"])
+                ])
+            }
+            failure["actions"] = failure["actions"] - whitelisted_actions
+            if failure["actions"]:
+                clean_failures.append(failure)
+
+        result.failed_rules = clean_failures

--- a/tests/test_rule_processor.py
+++ b/tests/test_rule_processor.py
@@ -13,12 +13,15 @@ CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
 
+import json
 
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
-from cfripper.model.enums import RuleMode, RuleRisk
+from cfripper.config.config import Config
+from cfripper.model.enums import RuleMode, RuleRisk, RuleGranularity
+from cfripper.model.result import Result
 from cfripper.model.rule_processor import RuleProcessor
-
+from pytest import fixture
 
 EXAMPLE_CF_TEMPLATE = {
     "AWSTemplateFormatVersion": "2010-09-09",
@@ -78,40 +81,453 @@ EXAMPLE_CF_TEMPLATE = {
 }
 
 
-class TestRuleProcessor:
-    def test_with_no_rules(self):
-        processor = RuleProcessor()
-        config = Mock()
-        result = Mock()
+def test_with_no_rules():
+    processor = RuleProcessor()
+    config = Mock()
+    result = Result()
 
-        processor.process_cf_template(EXAMPLE_CF_TEMPLATE, config, result)
+    processor.process_cf_template(EXAMPLE_CF_TEMPLATE, config, result)
 
-    def test_with_mock_rule(self):
-        rule = Mock()
 
-        processor = RuleProcessor(rule)
+def test_with_mock_rule():
+    rule = Mock()
 
-        config = Mock()
-        result = Mock()
-        processor.process_cf_template(EXAMPLE_CF_TEMPLATE, config, result)
+    processor = RuleProcessor(rule)
 
-        rule.invoke.assert_called()
+    config = Mock()
+    result = Result()
+    processor.process_cf_template(EXAMPLE_CF_TEMPLATE, config, result)
 
-    def test_remove_debug_rules(self):
-        original_failed_monitored_rules = [
-            {"rule": "a", "reason": "something", "rule_mode": RuleMode.MONITOR, "risk_value": RuleRisk.HIGH},
-            {"rule": "b", "reason": "something", "rule_mode": RuleMode.DEBUG, "risk_value": RuleRisk.MEDIUM},
-            {"rule": "c", "reason": "something", "rule_mode": RuleMode.MONITOR, "risk_value": RuleRisk.LOW},
-        ]
+    rule.invoke.assert_called()
 
-        list_with_no_debug_rules = [
-            {"rule": "a", "reason": "something", "rule_mode": RuleMode.MONITOR, "risk_value": RuleRisk.HIGH},
-            {"rule": "c", "reason": "something", "rule_mode": RuleMode.MONITOR, "risk_value": RuleRisk.LOW},
-        ]
 
-        processed_list = RuleProcessor.remove_debug_rules(rules=original_failed_monitored_rules)
-        assert list_with_no_debug_rules == processed_list
+def test_remove_debug_rules():
+    original_failed_monitored_rules = [
+        {"rule": "a", "reason": "something", "rule_mode": RuleMode.MONITOR, "risk_value": RuleRisk.HIGH},
+        {"rule": "b", "reason": "something", "rule_mode": RuleMode.DEBUG, "risk_value": RuleRisk.MEDIUM},
+        {"rule": "c", "reason": "something", "rule_mode": RuleMode.MONITOR, "risk_value": RuleRisk.LOW},
+    ]
 
-    def test_remove_debug_rules_no_rules(self):
-        processed_list = RuleProcessor.remove_debug_rules(rules=[])
-        assert [] == processed_list
+    list_with_no_debug_rules = [
+        {"rule": "a", "reason": "something", "rule_mode": RuleMode.MONITOR, "risk_value": RuleRisk.HIGH},
+        {"rule": "c", "reason": "something", "rule_mode": RuleMode.MONITOR, "risk_value": RuleRisk.LOW},
+    ]
+
+    processed_list = RuleProcessor.remove_debug_rules(rules=original_failed_monitored_rules)
+    assert list_with_no_debug_rules == processed_list
+
+
+def test_remove_debug_rules_no_rules():
+    processed_list = RuleProcessor.remove_debug_rules(rules=[])
+    assert [] == processed_list
+
+
+@fixture()
+def mock_rule_to_resource_whitelist():
+    yield {
+        "S3CrossAccountTrustRule": {
+            "teststack": {
+                ".*",
+            },
+            "otherstack": {
+                "rolething",
+            }
+        }
+    }
+
+
+def test_remove_failures_from_whitelisted_resources_uses_whitelist(mock_rule_to_resource_whitelist):
+
+    config = Config(
+        stack_name="otherstack",
+        rules=["S3CrossAccountTrustRule"],
+        rule_to_resource_whitelist=mock_rule_to_resource_whitelist,
+    )
+
+    result = Result()
+    result.failed_rules = [
+        {
+            "rule": "S3CrossAccountTrustRule",
+            "reason": "rolething has forbidden cross-account policy allow with 123456789 for an S3 bucket.",
+            "rule_mode": RuleMode.BLOCKING,
+            "risk_value": RuleRisk.HIGH,
+            "resource_ids": {"rolething"},
+            "actions": None,
+            "granularity": RuleGranularity.RESOURCE,
+        },
+        {
+            "rule": "S3CrossAccountTrustRule",
+            "reason": "anotherthing has forbidden cross-account policy allow with 123456789 for an S3 bucket.",
+            "rule_mode": RuleMode.BLOCKING,
+            "risk_value": RuleRisk.HIGH,
+            "resource_ids": {"anotherthing"},
+            "actions": None,
+            "granularity": RuleGranularity.RESOURCE,
+        }
+    ]
+
+    RuleProcessor.remove_failures_of_whitelisted_resources(config=config, result=result)
+    assert result.failed_rules == [{
+        "rule": "S3CrossAccountTrustRule",
+        "reason": "anotherthing has forbidden cross-account policy allow with 123456789 for an S3 bucket.",
+        "rule_mode": RuleMode.BLOCKING,
+        "risk_value": RuleRisk.HIGH,
+        "resource_ids": {"anotherthing"},
+        "actions": None,
+        "granularity": RuleGranularity.RESOURCE,
+    }]
+
+
+@patch("cfripper.model.rule_processor.logger.warning")
+def test_remove_failures_from_whitelisted_resources_failure_no_resources_is_removed(mock_logger, mock_rule_to_resource_whitelist):
+    config = Config(
+        stack_name="otherstack",
+        rules=["S3CrossAccountTrustRule"],
+        rule_to_resource_whitelist=mock_rule_to_resource_whitelist,
+    )
+
+    result = Result()
+    failure = {
+        "rule": "S3CrossAccountTrustRule",
+        "reason": "rolething has forbidden cross-account policy allow with 123456789 for an S3 bucket.",
+        "rule_mode": RuleMode.BLOCKING,
+        "risk_value": RuleRisk.HIGH,
+        "actions": None,
+        "granularity": RuleGranularity.RESOURCE,
+    }
+    result.failed_rules = [failure]
+
+    RuleProcessor.remove_failures_of_whitelisted_resources(config=config, result=result)
+    assert result.failed_rules == []
+    mock_logger.assert_called_once_with(f"Failure with resource granularity doesn't have resources: {failure}")
+
+
+def test_remove_failures_from_whitelisted_resources_only_removes_resource_granularity(mock_rule_to_resource_whitelist):
+    config = Config(
+        stack_name="otherstack",
+        rules=["S3CrossAccountTrustRule"],
+        rule_to_resource_whitelist=mock_rule_to_resource_whitelist,
+    )
+
+    result = Result()
+    failed_rules = [
+        {
+            "rule": "S3CrossAccountTrustRule",
+            "reason": "rolething has forbidden cross-account policy allow with 123456789 for an S3 bucket.",
+            "rule_mode": RuleMode.BLOCKING,
+            "risk_value": RuleRisk.HIGH,
+            "resource_ids": {"rolething"},
+            "actions": None,
+            "granularity": RuleGranularity.ACTION,
+        },
+        {
+            "rule": "S3CrossAccountTrustRule",
+            "reason": "anotherthing has forbidden cross-account policy allow with 123456789 for an S3 bucket.",
+            "rule_mode": RuleMode.BLOCKING,
+            "risk_value": RuleRisk.HIGH,
+            "resource_ids": {"anotherthing"},
+            "actions": None,
+            "granularity": RuleGranularity.RESOURCE,
+        }
+    ]
+    result.failed_rules = failed_rules
+
+    RuleProcessor.remove_failures_of_whitelisted_resources(config=config, result=result)
+    assert result.failed_rules == failed_rules
+
+
+def test_can_whitelist_resource_from_any_stack_if_granularity_is_resource():
+
+    whitelist_for_all_stacks = {
+        "S3CrossAccountTrustRule": {
+            ".*": {
+                "ProductionAccessTest",
+            },
+            "otherstack": {
+                "rolething",
+            }
+        },
+    }
+    config = Config(
+        stack_name="abcd",
+        rules=["S3CrossAccountTrustRule"],
+        rule_to_resource_whitelist=whitelist_for_all_stacks,
+    )
+
+    result = Result()
+    failed_rules = [
+        {
+            "rule": "S3CrossAccountTrustRule",
+            "reason": "ProductionAccessTest has forbidden cross-account policy allow with 123456789 for an S3 bucket.",
+            "rule_mode": RuleMode.BLOCKING,
+            "risk_value": RuleRisk.HIGH,
+            "resource_ids": {"ProductionAccessTest"},
+            "actions": None,
+            "granularity": RuleGranularity.RESOURCE,
+        },
+        {
+            "rule": "S3CrossAccountTrustRule",
+            "reason": "This one isn't whitelisted because granularity is ACTION and not RESOURCE",
+            "rule_mode": RuleMode.BLOCKING,
+            "risk_value": RuleRisk.HIGH,
+            "resource_ids": {"ProductionAccessTest"},
+            "actions": None,
+            "granularity": RuleGranularity.ACTION,
+        },
+    ]
+    result.failed_rules = failed_rules
+
+    RuleProcessor.remove_failures_of_whitelisted_resources(config=config, result=result)
+    assert result.failed_rules == [{
+        "rule": "S3CrossAccountTrustRule",
+        "reason": "This one isn't whitelisted because granularity is ACTION and not RESOURCE",
+        "rule_mode": RuleMode.BLOCKING,
+        "risk_value": RuleRisk.HIGH,
+        "resource_ids": {"ProductionAccessTest"},
+        "actions": None,
+        "granularity": RuleGranularity.ACTION,
+    }]
+
+
+def test_only_whitelisted_resources_are_removed(mock_rule_to_resource_whitelist):
+    config = Config(
+        stack_name="otherstack",
+        rules=["S3CrossAccountTrustRule"],
+        rule_to_resource_whitelist=mock_rule_to_resource_whitelist,
+    )
+
+    result = Result()
+    failed_rules = [
+        {
+            "rule": "S3CrossAccountTrustRule",
+            "reason": "Forbidden cross-account policy allow with 123456789 for an S3 bucket.",
+            "rule_mode": RuleMode.BLOCKING,
+            "risk_value": RuleRisk.HIGH,
+            "resource_ids": {"rolething", "thenotwhitelistedthing", "anotherone"},
+            "actions": None,
+            "granularity": RuleGranularity.RESOURCE,
+        },
+    ]
+    result.failed_rules = failed_rules
+
+    RuleProcessor.remove_failures_of_whitelisted_resources(config=config, result=result)
+    assert result.failed_rules == [
+        {
+            "rule": "S3CrossAccountTrustRule",
+            "reason": "Forbidden cross-account policy allow with 123456789 for an S3 bucket.",
+            "rule_mode": RuleMode.BLOCKING,
+            "risk_value": RuleRisk.HIGH,
+            "resource_ids": {"thenotwhitelistedthing", "anotherone"},
+            "actions": None,
+            "granularity": RuleGranularity.RESOURCE,
+        },
+    ]
+
+
+@fixture()
+def mock_rule_to_action_whitelist():
+    yield {
+        "WildcardResourceRule": {
+            "teststack": {
+                "s3:*",
+            },
+            "otherstack": {
+                "dynamodb:*",
+            }
+        }
+    }
+
+
+def test_remove_failures_from_whitelisted_actions_uses_whitelist(mock_rule_to_action_whitelist):
+
+    config = Config(
+        stack_name="teststack",
+        rules=["WildcardResourceRule"],
+        rule_to_action_whitelist=mock_rule_to_action_whitelist,
+    )
+
+    result = Result()
+    result.failed_rules = [
+        {
+            "rule": "WildcardResourceRule",
+            "reason": "rolething is using a wildcard resource in BucketAccessPolicy",
+            "rule_mode": RuleMode.BLOCKING,
+            "risk_value": RuleRisk.HIGH,
+            "resource_ids": {"BucketAccessPolicy"},
+            "actions": {"s3:Get*"},
+            "granularity": RuleGranularity.ACTION,
+        },
+        {
+            "rule": "WildcardResourceRule",
+            "reason": "rolething is using a wildcard resource in DynamoAccessPolicy",
+            "rule_mode": RuleMode.BLOCKING,
+            "risk_value": RuleRisk.HIGH,
+            "resource_ids": {"DynamoAccessPolicy"},
+            "actions": {"dynamodb:Get"},
+            "granularity": RuleGranularity.ACTION,
+        }
+    ]
+
+    RuleProcessor.remove_failures_of_whitelisted_actions(config=config, result=result)
+    assert result.failed_rules == [{
+        "rule": "WildcardResourceRule",
+        "reason": "rolething is using a wildcard resource in DynamoAccessPolicy",
+        "rule_mode": RuleMode.BLOCKING,
+        "risk_value": RuleRisk.HIGH,
+        "resource_ids": {"DynamoAccessPolicy"},
+        "actions": {"dynamodb:Get"},
+        "granularity": RuleGranularity.ACTION,
+    }]
+
+
+@patch("cfripper.model.rule_processor.logger.warning")
+def test_remove_failures_from_whitelisted_actions_failure_no_actions_is_removed(mock_logger, mock_rule_to_action_whitelist):
+    config = Config(
+        stack_name="teststack",
+        rules=["S3CrossAccountTrustRule"],
+        rule_to_action_whitelist=mock_rule_to_action_whitelist,
+    )
+
+    result = Result()
+    failure = {
+        "rule": "S3CrossAccountTrustRule",
+        "reason": "rolething has forbidden cross-account policy allow with 123456789 for an S3 bucket.",
+        "rule_mode": RuleMode.BLOCKING,
+        "risk_value": RuleRisk.HIGH,
+        "actions": set(),
+        "granularity": RuleGranularity.ACTION,
+    }
+    result.failed_rules = [failure]
+
+    RuleProcessor.remove_failures_of_whitelisted_actions(config=config, result=result)
+    assert result.failed_rules == []
+    mock_logger.assert_called_once_with(f"Failure with action granularity doesn't have actions: {failure}")
+
+
+def test_remove_failures_from_whitelisted_actions_only_removes_action_granularity(mock_rule_to_action_whitelist):
+    config = Config(
+        stack_name="teststack",
+        rules=["S3CrossAccountTrustRule"],
+        rule_to_action_whitelist=mock_rule_to_action_whitelist,
+    )
+
+    result = Result()
+    failed_rules = [
+        {
+            "rule": "WildcardResourceRule",
+            "reason": "rolething is using a wildcard resource in BucketAccessPolicy",
+            "rule_mode": RuleMode.BLOCKING,
+            "risk_value": RuleRisk.HIGH,
+            "resource_ids": {"BucketAccessPolicy"},
+            "actions": {"s3:Get*"},
+            "granularity": RuleGranularity.ACTION,
+        },
+        {
+            "rule": "WildcardResourceRule",
+            "reason": "rolething is using a wildcard resource in BucketAccessPolicy",
+            "rule_mode": RuleMode.BLOCKING,
+            "risk_value": RuleRisk.HIGH,
+            "resource_ids": set(),
+            "actions": set(),
+            "granularity": RuleGranularity.STACK,
+        },
+    ]
+    result.failed_rules = failed_rules
+
+    RuleProcessor.remove_failures_of_whitelisted_actions(config=config, result=result)
+    assert result.failed_rules == [
+        {
+            "rule": "WildcardResourceRule",
+            "reason": "rolething is using a wildcard resource in BucketAccessPolicy",
+            "rule_mode": RuleMode.BLOCKING,
+            "risk_value": RuleRisk.HIGH,
+            "resource_ids": set(),
+            "actions": set(),
+            "granularity": RuleGranularity.STACK,
+        },
+    ]
+
+
+def test_can_whitelist_action_from_any_stack_if_granularity_is_action():
+
+    whitelist_for_all_stacks = {
+        "S3CrossAccountTrustRule": {
+            ".*": {
+                "s3:ListBucket",
+            },
+        },
+    }
+    config = Config(
+        stack_name="abcd",
+        rules=["S3CrossAccountTrustRule"],
+        rule_to_action_whitelist=whitelist_for_all_stacks,
+    )
+
+    result = Result()
+    failed_rules = [
+        {
+            "rule": "S3CrossAccountTrustRule",
+            "reason": "ProductionAccessTest has forbidden cross-account policy allow with 123456789 for an S3 bucket.",
+            "rule_mode": RuleMode.BLOCKING,
+            "risk_value": RuleRisk.HIGH,
+            "actions": {"s3:ListBucket"},
+            "granularity": RuleGranularity.ACTION,
+        },
+        {
+            "rule": "S3CrossAccountTrustRule",
+            "reason": "This one isn't whitelisted because granularity is STACK and not ACTION",
+            "rule_mode": RuleMode.BLOCKING,
+            "risk_value": RuleRisk.HIGH,
+            "actions": None,
+            "granularity": RuleGranularity.STACK,
+        },
+    ]
+    result.failed_rules = failed_rules
+
+    RuleProcessor.remove_failures_of_whitelisted_actions(config=config, result=result)
+    assert result.failed_rules == [{
+        "rule": "S3CrossAccountTrustRule",
+        "reason": "This one isn't whitelisted because granularity is STACK and not ACTION",
+        "rule_mode": RuleMode.BLOCKING,
+        "risk_value": RuleRisk.HIGH,
+        "actions": None,
+        "granularity": RuleGranularity.STACK,
+    }]
+
+
+def test_action_whitelist_keeps_non_whitelisted_actions():
+    whitelist_for_all_stacks = {
+        "MockRule": {
+            ".*": {
+                "s3:List",
+            },
+        },
+    }
+    config = Config(
+        stack_name="abcd",
+        rules=["MockRule"],
+        rule_to_action_whitelist=whitelist_for_all_stacks,
+    )
+
+    result = Result()
+    failed_rules = [
+        {
+            "rule": "MockRule",
+            "reason": "MockRule is invalid for some actions",
+            "rule_mode": RuleMode.BLOCKING,
+            "risk_value": RuleRisk.HIGH,
+            "actions": {"s3:ListBucket", "s3:GetBucket"},
+            "granularity": RuleGranularity.ACTION,
+        },
+    ]
+    result.failed_rules = failed_rules
+
+    RuleProcessor.remove_failures_of_whitelisted_actions(config=config, result=result)
+    assert result.failed_rules == [{
+        "rule": "MockRule",
+        "reason": "MockRule is invalid for some actions",
+        "rule_mode": RuleMode.BLOCKING,
+        "risk_value": RuleRisk.HIGH,
+        "actions": {"s3:GetBucket"},
+        "granularity": RuleGranularity.ACTION,
+    }]

--- a/tests/test_rule_processor.py
+++ b/tests/test_rule_processor.py
@@ -81,12 +81,16 @@ EXAMPLE_CF_TEMPLATE = {
 }
 
 
-def test_with_no_rules():
+@patch.object(RuleProcessor, "remove_failures_of_whitelisted_resources")
+@patch.object(RuleProcessor, "remove_failures_of_whitelisted_actions")
+def test_with_no_rules(mock_remove_whitelisted_actions, mock_remove_whitelisted_resources):
     processor = RuleProcessor()
     config = Mock()
     result = Result()
 
     processor.process_cf_template(EXAMPLE_CF_TEMPLATE, config, result)
+    mock_remove_whitelisted_actions.assert_called()
+    mock_remove_whitelisted_resources.assert_called()
 
 
 def test_with_mock_rule():


### PR DESCRIPTION
## Context
Following the update to having a generic whitelist for resources and another one for actions, this update adds the option to add a list of resource_ids and/or actions to the failure.
It also introduces the concept of failure granularity, each failure has a granularity which can be:
- Stack: Applies to all stack
- Resource: Applies to a set of resources in the stack
- Action: Applies to a set of actions in the stack
The new methods added in the rule processor will use the granularity of the failure along with the new whitelists that were already added to filter the failures that contain affect ONLY whitelisted resources or failures according to the failure granularity.

## Changes
- Added a granularity enum
- Added methods to remove whitelisted failures and resources to the rule processor, the methods are called after processing the rules.
- Added tests to cover every possible use case

I will wait until the current PR's are merged to merge the changes into this branch and solve the possible merge conflicts here.