### PR TITLE
Fix serialization bug in lambda handler usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-- '3.6'
+- '3.7'
 install:
 - make install-dev
 script:

--- a/cfripper/main.py
+++ b/cfripper/main.py
@@ -120,10 +120,14 @@ def handler(event, context):
 
     return {
         "valid": result.valid,
-        "reason": ",".join(["{}-{}".format(r["rule"], r["reason"]) for r in result.failed_rules]),
-        "failed_rules": RuleProcessor.remove_debug_rules(rules=result.failed_rules),
+        "reason": ",".join(["{}-{}".format(r.rule, r.reason) for r in result.failed_rules]),
+        "failed_rules": [
+            failure.serializable() for failure in RuleProcessor.remove_debug_rules(rules=result.failed_rules)
+        ],
         "exceptions": [x.args[0] for x in result.exceptions],
-        "warnings": RuleProcessor.remove_debug_rules(rules=result.failed_monitored_rules),
+        "warnings": [
+            failure.serializable() for failure in RuleProcessor.remove_debug_rules(rules=result.failed_monitored_rules)
+        ],
     }
 
 

--- a/cfripper/model/result.py
+++ b/cfripper/model/result.py
@@ -12,30 +12,46 @@ under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from typing import Dict
+from dataclasses import dataclass, field
+from typing import List, Optional
 
 from cfripper.model.enums import RuleMode
 
 
+@dataclass
+class Failure:
+    granularity: str
+    reason: str
+    risk_value: str
+    rule: str
+    rule_mode: str
+    actions: Optional[set] = field(default_factory=set)
+    resource_ids: Optional[set] = field(default_factory=set)
+
+    def serializable(self):
+        return {
+            "rule": self.rule,
+            "reason": self.reason,
+            "rule_mode": self.rule_mode,
+            "risk_value": self.risk_value,
+            "resource_ids": list(self.resource_ids or []),
+            "actions": list(self.actions or []),
+            "granularity": self.granularity
+        }
+
+
+@dataclass
 class Result:
     """An object to represent scan results."""
 
-    def __init__(self):
-        self.valid = True
-        self.failed_rules = []
-        self.exceptions = []
-        self.failed_monitored_rules = []
-        self.warnings = []
+    valid: bool = True
+    failed_rules: List[Failure] = field(default_factory=list)
+    exceptions: List = field(default_factory=list)
+    failed_monitored_rules: List[Failure] = field(default_factory=list)
+    warnings: List[Failure] = field(default_factory=list)
 
     def add_failure(
-        self,
-        rule: str,
-        reason: str,
-        rule_mode: str,
-        risk_value: str,
-        granularity: str,
-        resource_ids=None,
-        actions=None,
+        self, rule: str, reason: str, rule_mode: str, risk_value: str, granularity: str, resource_ids=None, actions=None
     ):
 
         if resource_ids is None:
@@ -44,15 +60,15 @@ class Result:
         if actions is None:
             actions = set()
 
-        failure = {
-            "rule": rule,
-            "reason": reason,
-            "rule_mode": rule_mode,
-            "risk_value": risk_value,
-            "resource_ids": resource_ids,
-            "actions": actions,
-            "granularity": granularity,
-        }
+        failure = Failure(
+            rule=rule,
+            reason=reason,
+            rule_mode=rule_mode,
+            risk_value=risk_value,
+            resource_ids=resource_ids,
+            actions=actions,
+            granularity=granularity,
+        )
 
         if rule_mode is not RuleMode.BLOCKING:
             self.add_failure_monitored_rule(failure=failure)
@@ -66,11 +82,11 @@ class Result:
     def add_exception(self, ex):
         self.exceptions.append(ex)
 
-    def add_warning(self, warning):
+    def add_warning(self, warning: Failure):
         self.warnings.append(warning)
 
-    def add_failure_monitored_rule(self, failure: Dict):
+    def add_failure_monitored_rule(self, failure: Failure):
         self.failed_monitored_rules.append(failure)
 
-    def add_failure_blocking_rule(self, failure: Dict):
+    def add_failure_blocking_rule(self, failure: Failure):
         self.failed_rules.append(failure)

--- a/cfripper/model/rule_processor.py
+++ b/cfripper/model/rule_processor.py
@@ -14,13 +14,14 @@ specific language governing permissions and limitations under the License.
 """
 import logging
 import re
+from typing import List
 
 import pycfmodel
 
 from cfripper.config.config import Config
 from cfripper.model.enums import RuleMode, RuleGranularity
 from cfripper.model.managed_policy_transformer import ManagedPolicyTransformer
-from cfripper.model.result import Result
+from cfripper.model.result import Result, Failure
 
 logger = logging.getLogger(__file__)
 
@@ -59,8 +60,8 @@ class RuleProcessor:
         self.remove_failures_of_whitelisted_resources(config=config, result=result)
 
     @staticmethod
-    def remove_debug_rules(rules):
-        return [rule for rule in rules if rule["rule_mode"] != RuleMode.DEBUG]
+    def remove_debug_rules(rules: List[Failure]):
+        return [rule for rule in rules if rule.rule_mode != RuleMode.DEBUG]
 
     @staticmethod
     def remove_failures_of_whitelisted_resources(config: Config, result: Result):
@@ -71,24 +72,24 @@ class RuleProcessor:
         clean_failures = []
 
         for failure in result.failed_rules:
-            if failure["granularity"] != RuleGranularity.RESOURCE:
+            if failure.granularity != RuleGranularity.RESOURCE:
                 clean_failures.append(failure)
                 continue
 
-            if not failure.get("resource_ids"):
+            if not failure.resource_ids:
                 logger.warning(f"Failure with resource granularity doesn't have resources: {failure}")
                 continue
 
             whitelisted_resources = {
                 resource
-                for resource in failure["resource_ids"]
+                for resource in failure.resource_ids
                 if any([
                     re.match(whitelisted_resource_regex, resource)
-                    for whitelisted_resource_regex in config.get_whitelisted_resources(failure["rule"])
+                    for whitelisted_resource_regex in config.get_whitelisted_resources(failure.rule)
                 ])
             }
-            failure["resource_ids"] = failure["resource_ids"] - whitelisted_resources
-            if failure["resource_ids"]:
+            failure.resource_ids = failure.resource_ids - whitelisted_resources
+            if failure.resource_ids:
                 clean_failures.append(failure)
 
         result.failed_rules = clean_failures
@@ -102,24 +103,24 @@ class RuleProcessor:
         clean_failures = []
 
         for failure in result.failed_rules:
-            if failure["granularity"] != RuleGranularity.ACTION:
+            if failure.granularity != RuleGranularity.ACTION:
                 clean_failures.append(failure)
                 continue
 
-            if not failure.get("actions"):
+            if not failure.actions:
                 logger.warning(f"Failure with action granularity doesn't have actions: {failure}")
                 continue
 
             whitelisted_actions = {
                 action
-                for action in failure["actions"]
+                for action in failure.actions
                 if any([
                     re.match(whitelisted_action_regex, action)
-                    for whitelisted_action_regex in config.get_whitelisted_actions(failure["rule"])
+                    for whitelisted_action_regex in config.get_whitelisted_actions(failure.rule)
                 ])
             }
-            failure["actions"] = failure["actions"] - whitelisted_actions
-            if failure["actions"]:
+            failure.actions = failure.actions - whitelisted_actions
+            if failure.actions:
                 clean_failures.append(failure)
 
         result.failed_rules = clean_failures

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ dev_requires = ["flake8>=3.3.0", "pytest>=3.6", "pytest-cov>=2.5.1", "pip-tools=
 
 setup(
     name="cfripper",
-    version="0.7.2",
+    version="0.8.0",
     author="Skyscanner Product Security",
     author_email="security@skyscanner.net",
     long_description=long_description,
@@ -18,6 +18,7 @@ setup(
     description='Lambda function to "rip apart" a CloudFormation template and check it for security compliance.',
     packages=find_packages(),
     platforms="any",
+    python_requires=">=3.7",
     install_requires=install_requires,
     tests_require=dev_requires,
     extras_require={"dev": dev_requires},

--- a/tests/test_cross_account.py
+++ b/tests/test_cross_account.py
@@ -73,10 +73,10 @@ class TestCrossAccountTrustRule:
         assert len(result.failed_rules) == 2
         assert len(result.failed_monitored_rules) == 0
         assert (
-            result.failed_rules[0]["reason"]
+            result.failed_rules[0].reason
             == "RootRole has forbidden cross-account trust relationship with arn:aws:iam::123456789:root"
         )
         assert (
-            result.failed_rules[1]["reason"]
+            result.failed_rules[1].reason
             == "RootRole has forbidden cross-account trust relationship with arn:aws:iam::999999999:role/someuser@bla.com"
         )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -52,6 +52,7 @@ class TestMainHandler:
 
         mock_created_rule_processor_object = Mock()
         mock_rule_processor = Mock(return_value=mock_created_rule_processor_object)
+        mock_rule_processor.remove_debug_rules.return_value = []
 
         with patch("cfripper.main.Boto3Client", new=mock_boto3_adapter):
             with patch("cfripper.main.RuleProcessor", new=mock_rule_processor):

--- a/tests/test_rule_cloud_formation_authentication.py
+++ b/tests/test_rule_cloud_formation_authentication.py
@@ -46,7 +46,7 @@ class TestCloudFormationAuthenticationJson:
         assert not result.valid
         assert len(result.failed_rules) == 1
         assert len(result.failed_monitored_rules) == 0
-        assert result.failed_rules[0]["reason"] == "Possible hardcoded credentials in EC2I4LBA1"
+        assert result.failed_rules[0].reason == "Possible hardcoded credentials in EC2I4LBA1"
 
     # This should pass CFRipper, currently does not. Needs to be looked into.
     # Issue is pycfmodel is marking it as containing hardcoded credentials, but this is not true.
@@ -59,4 +59,4 @@ class TestCloudFormationAuthenticationJson:
         assert not result.valid
         assert len(result.failed_rules) == 1
         assert len(result.failed_monitored_rules) == 0
-        assert result.failed_rules[0]["reason"] == "Possible hardcoded credentials in EC2I4LBA1"
+        assert result.failed_rules[0].reason == "Possible hardcoded credentials in EC2I4LBA1"

--- a/tests/test_rule_cross_account_trust.py
+++ b/tests/test_rule_cross_account_trust.py
@@ -20,7 +20,7 @@ from cfripper.rules import DEFAULT_RULES
 
 from cfripper.rules.CrossAccountTrustRule import CrossAccountTrustRule
 from cfripper.config.config import Config
-from cfripper.model.result import Result
+from cfripper.model.result import Result, Failure
 
 
 @pytest.fixture()
@@ -42,42 +42,42 @@ def template_two_roles_dict():
 @pytest.fixture()
 def expected_result_two_roles():
     return [
-        {
-            "rule": "CrossAccountTrustRule",
-            "reason": "RootRoleOne has forbidden cross-account trust relationship with arn:aws:iam::123456789:root",
-            "rule_mode": RuleMode.BLOCKING,
-            "risk_value": RuleRisk.MEDIUM,
-            "resource_ids": {"RootRoleOne"},
-            "actions": set(),
-            "granularity": RuleGranularity.RESOURCE,
-        },
-        {
-            "rule": "CrossAccountTrustRule",
-            "reason": "RootRoleOne has forbidden cross-account trust relationship with arn:aws:iam::999999999:role/someuser@bla.com",
-            "rule_mode": RuleMode.BLOCKING,
-            "risk_value": RuleRisk.MEDIUM,
-            "resource_ids": {"RootRoleOne"},
-            "actions": set(),
-            "granularity": RuleGranularity.RESOURCE,
-        },
-        {
-            "rule": "CrossAccountTrustRule",
-            "reason": "RootRoleTwo has forbidden cross-account trust relationship with arn:aws:iam::123456789:root",
-            "rule_mode": RuleMode.BLOCKING,
-            "risk_value": RuleRisk.MEDIUM,
-            "resource_ids": {"RootRoleTwo"},
-            "actions": set(),
-            "granularity": RuleGranularity.RESOURCE,
-        },
-        {
-            "rule": "CrossAccountTrustRule",
-            "reason": "RootRoleTwo has forbidden cross-account trust relationship with arn:aws:iam::999999999:role/someuser@bla.com",
-            "rule_mode": RuleMode.BLOCKING,
-            "risk_value": RuleRisk.MEDIUM,
-            "resource_ids": {"RootRoleTwo"},
-            "actions": set(),
-            "granularity": RuleGranularity.RESOURCE,
-        },
+        Failure(
+            rule="CrossAccountTrustRule",
+            reason="RootRoleOne has forbidden cross-account trust relationship with arn:aws:iam::123456789:root",
+            rule_mode=RuleMode.BLOCKING,
+            risk_value=RuleRisk.MEDIUM,
+            resource_ids={"RootRoleOne"},
+            actions=set(),
+            granularity=RuleGranularity.RESOURCE,
+        ),
+        Failure(
+            rule="CrossAccountTrustRule",
+            reason="RootRoleOne has forbidden cross-account trust relationship with arn:aws:iam::999999999:role/someuser@bla.com",
+            rule_mode=RuleMode.BLOCKING,
+            risk_value=RuleRisk.MEDIUM,
+            resource_ids={"RootRoleOne"},
+            actions=set(),
+            granularity=RuleGranularity.RESOURCE,
+        ),
+        Failure(
+            rule="CrossAccountTrustRule",
+            reason="RootRoleTwo has forbidden cross-account trust relationship with arn:aws:iam::123456789:root",
+            rule_mode=RuleMode.BLOCKING,
+            risk_value=RuleRisk.MEDIUM,
+            resource_ids={"RootRoleTwo"},
+            actions=set(),
+            granularity=RuleGranularity.RESOURCE,
+        ),
+        Failure(
+            rule="CrossAccountTrustRule",
+            reason="RootRoleTwo has forbidden cross-account trust relationship with arn:aws:iam::999999999:role/someuser@bla.com",
+            rule_mode=RuleMode.BLOCKING,
+            risk_value=RuleRisk.MEDIUM,
+            resource_ids={"RootRoleTwo"},
+            actions=set(),
+            granularity=RuleGranularity.RESOURCE,
+        ),
     ]
 
 
@@ -88,27 +88,27 @@ def test_report_format_is_the_one_expected(template_one_role):
 
     assert not result.valid
     assert result.failed_rules == [
-        {
-            "rule": "CrossAccountTrustRule",
-            "reason": "RootRole has forbidden cross-account trust relationship with arn:aws:iam::123456789:root",
-            "rule_mode": RuleMode.BLOCKING,
-            "risk_value": RuleRisk.MEDIUM,
-            "resource_ids": {"RootRole"},
-            "actions": set(),
-            "granularity": RuleGranularity.RESOURCE,
-        },
-        {
-            "rule": "CrossAccountTrustRule",
-            "reason": (
+        Failure(
+            rule="CrossAccountTrustRule",
+            reason="RootRole has forbidden cross-account trust relationship with arn:aws:iam::123456789:root",
+            rule_mode=RuleMode.BLOCKING,
+            risk_value=RuleRisk.MEDIUM,
+            resource_ids={"RootRole"},
+            actions=set(),
+            granularity=RuleGranularity.RESOURCE,
+        ),
+        Failure(
+            rule="CrossAccountTrustRule",
+            reason=(
                 "RootRole has forbidden cross-account trust relationship with arn:aws:iam::999999999:role/"
                 "someuser@bla.com"
             ),
-            "rule_mode": RuleMode.BLOCKING,
-            "risk_value": RuleRisk.MEDIUM,
-            "resource_ids": {"RootRole"},
-            "actions": set(),
-            "granularity": RuleGranularity.RESOURCE,
-        },
+            rule_mode=RuleMode.BLOCKING,
+            risk_value=RuleRisk.MEDIUM,
+            resource_ids={"RootRole"},
+            actions=set(),
+            granularity=RuleGranularity.RESOURCE,
+        )
     ]
 
 

--- a/tests/test_rule_hardcoded_rds_password.py
+++ b/tests/test_rule_hardcoded_rds_password.py
@@ -39,4 +39,4 @@ class TestHardcodedRDSPassword:
         assert not result.valid
         assert len(result.failed_rules) == 2
         assert len(result.failed_monitored_rules) == 0
-        assert result.failed_rules[0]["reason"] == "Default RDS password parameter or missing NoEcho for BadDb3."
+        assert result.failed_rules[0].reason == "Default RDS password parameter or missing NoEcho for BadDb3."

--- a/tests/test_rule_iam_managed_policy_wildcard_action.py
+++ b/tests/test_rule_iam_managed_policy_wildcard_action.py
@@ -39,4 +39,4 @@ class TestIAMManagedPolicyWildcardActionRule:
         assert not result.valid
         assert len(result.failed_rules) == 1
         assert len(result.failed_monitored_rules) == 0
-        assert result.failed_rules[0]["reason"] == "IAM managed policy CreateTestDBPolicy3 should not allow * action"
+        assert result.failed_rules[0].reason == "IAM managed policy CreateTestDBPolicy3 should not allow * action"

--- a/tests/test_rule_iam_wildcard_on_trust_policy.py
+++ b/tests/test_rule_iam_wildcard_on_trust_policy.py
@@ -40,6 +40,6 @@ class TestIAMRoleWildcardActionOnTrustPolicyRule:
         assert len(result.failed_rules) == 1
         assert len(result.failed_monitored_rules) == 0
         assert (
-            result.failed_rules[0]["reason"]
+            result.failed_rules[0].reason
             == "IAM role WildcardActionRole should not allow * action on its trust policy"
         )

--- a/tests/test_rule_security_group_missing_egress.py
+++ b/tests/test_rule_security_group_missing_egress.py
@@ -39,6 +39,7 @@ class TestSecurityGroupMissingEgressRule:
         assert result.valid
         assert len(result.failed_monitored_rules) == 1
         assert (
-            result.failed_monitored_rules[0]["reason"]
-            == "Missing egress rule in sg means all traffic is allowed outbound. Make this explicit if it is desired configuration"
+            result.failed_monitored_rules[0].reason
+            == "Missing egress rule in sg means all traffic is allowed outbound."
+               " Make this explicit if it is desired configuration"
         )

--- a/tests/test_rules_iam_roles_overprivileged.py
+++ b/tests/test_rules_iam_roles_overprivileged.py
@@ -91,10 +91,10 @@ def test_with_invalid_role_inline_policy():
 
     assert not result.valid
     assert (
-        result.failed_rules[0]["reason"]
+        result.failed_rules[0].reason
         == 'Role "RootRole" contains an insecure permission "ec2:DeleteInternetGateway" in policy "not_so_chill_policy"'
     )
-    assert result.failed_rules[0]["rule"] == "IAMRolesOverprivilegedRule"
+    assert result.failed_rules[0].rule == "IAMRolesOverprivilegedRule"
 
 
 def test_with_invalid_role_inline_policy_resource_as_array():
@@ -130,10 +130,10 @@ def test_with_invalid_role_inline_policy_resource_as_array():
 
     assert not result.valid
     assert (
-        result.failed_rules[0]["reason"]
+        result.failed_rules[0].reason
         == 'Role "RootRole" contains an insecure permission "ec2:DeleteInternetGateway" in policy "not_so_chill_policy"'
     )
-    assert result.failed_rules[0]["rule"] == "IAMRolesOverprivilegedRule"
+    assert result.failed_rules[0].rule == "IAMRolesOverprivilegedRule"
 
 
 def test_with_valid_role_managed_policy():
@@ -176,10 +176,10 @@ def test_with_invalid_role_managed_policy():
 
     assert not result.valid
     assert (
-        result.failed_rules[0]["reason"]
+        result.failed_rules[0].reason
         == "Role RootRole has forbidden Managed Policy arn:aws:iam::aws:policy/AdministratorAccess"
     )
-    assert result.failed_rules[0]["rule"] == "IAMRolesOverprivilegedRule"
+    assert result.failed_rules[0].rule == "IAMRolesOverprivilegedRule"
 
 
 def test_with_invalid_role_inline_policy_fn_if():
@@ -233,7 +233,7 @@ def test_with_invalid_role_inline_policy_fn_if():
 
     assert not result.valid
     assert (
-        result.failed_rules[0]["reason"]
+        result.failed_rules[0].reason
         == 'Role "RootRole" contains an insecure permission "ec2:DeleteVpc" in policy "ProdCredentialStoreAccessPolicy"'
     )
-    assert result.failed_rules[0]["rule"] == "IAMRolesOverprivilegedRule"
+    assert result.failed_rules[0].rule == "IAMRolesOverprivilegedRule"

--- a/tests/test_rules_s3_bucket_wildcard_action.py
+++ b/tests/test_rules_s3_bucket_wildcard_action.py
@@ -39,4 +39,4 @@ class TestS3BucketPolicyWildcardActionRule:
         assert not result.valid
         assert len(result.failed_rules) == 2
         assert len(result.failed_monitored_rules) == 0
-        assert result.failed_rules[0]["reason"] == "S3 Bucket policy S3BucketPolicy should not allow * action"
+        assert result.failed_rules[0].reason == "S3 Bucket policy S3BucketPolicy should not allow * action"

--- a/tests/test_rules_s3_read_plus_list.py
+++ b/tests/test_rules_s3_read_plus_list.py
@@ -42,7 +42,7 @@ class TestS3BucketPublicReadAclAndListStatementRule:
         assert len(result.failed_rules) == 0
         assert len(result.failed_monitored_rules) == 2
         assert (
-            result.failed_monitored_rules[0]["reason"]
+            result.failed_monitored_rules[0].reason
             == "S3 Bucket S3Bucket should not have a public read acl and list bucket statement"
         )
-        assert result.failed_monitored_rules[0]["rule_mode"] == RuleMode.DEBUG
+        assert result.failed_monitored_rules[0].rule_mode == RuleMode.DEBUG

--- a/tests/test_rules_security_group_open_to_world.py
+++ b/tests/test_rules_security_group_open_to_world.py
@@ -38,8 +38,8 @@ class TestSecurityGroupOpenToWorldRule:
         rule.invoke(resources, [])
 
         assert not result.valid
-        assert result.failed_rules[0]["reason"] == 'Port 22 open to the world in security group "RootRole"'
-        assert result.failed_rules[0]["rule"] == "SecurityGroupOpenToWorldRule"
+        assert result.failed_rules[0].reason == 'Port 22 open to the world in security group "RootRole"'
+        assert result.failed_rules[0].rule == "SecurityGroupOpenToWorldRule"
 
     def test_valid_security_group_not_slash0(self):
         role_props = {
@@ -114,8 +114,8 @@ class TestSecurityGroupOpenToWorldRule:
         resources = parse(role_props).resources
         rule.invoke(resources, [])
 
-        assert result.failed_rules[0]["reason"] == 'Port 22 open to the world in security group "RootRole"'
-        assert result.failed_rules[0]["rule"] == "SecurityGroupOpenToWorldRule"
+        assert result.failed_rules[0].reason == 'Port 22 open to the world in security group "RootRole"'
+        assert result.failed_rules[0].rule == "SecurityGroupOpenToWorldRule"
 
     def test_invalid_security_group_range(self):
         role_props = {
@@ -133,8 +133,8 @@ class TestSecurityGroupOpenToWorldRule:
         resources = parse(role_props).resources
         rule.invoke(resources, [])
 
-        assert result.failed_rules[0]["reason"] == "Ports 0 - 100 open in Security Group RootRole"
-        assert result.failed_rules[0]["rule"] == "SecurityGroupOpenToWorldRule"
+        assert result.failed_rules[0].reason == "Ports 0 - 100 open in Security Group RootRole"
+        assert result.failed_rules[0].rule == "SecurityGroupOpenToWorldRule"
 
     def test_invalid_security_group_multiple_statements(self):
         role_props = {
@@ -157,8 +157,8 @@ class TestSecurityGroupOpenToWorldRule:
         resources = parse(role_props).resources
         rule.invoke(resources, [])
 
-        assert result.failed_rules[0]["reason"] == 'Port 9090 open to the world in security group "RootRole"'
-        assert result.failed_rules[0]["rule"] == "SecurityGroupOpenToWorldRule"
+        assert result.failed_rules[0].reason == 'Port 9090 open to the world in security group "RootRole"'
+        assert result.failed_rules[0].rule == "SecurityGroupOpenToWorldRule"
 
     def test_security_group_rules_as_refs(self):
 

--- a/tests/test_rules_sqs_policy_public.py
+++ b/tests/test_rules_sqs_policy_public.py
@@ -40,9 +40,9 @@ class TestSQSQueuePolicyPublicRule:
 
         assert not result.valid
         assert len(result.failed_rules) == 4
-        assert result.failed_rules[0]["reason"] == "SQS Queue policy QueuePolicyPublic1 should not be public"
-        assert result.failed_rules[1]["reason"] == "SQS Queue policy QueuePolicyPublic2 should not be public"
-        assert result.failed_rules[2]["reason"] == "SQS Queue policy QueuePolicyPublic3 should not be public"
-        assert result.failed_rules[3]["reason"] == "SQS Queue policy QueuePolicyPublic4 should not be public"
+        assert result.failed_rules[0].reason == "SQS Queue policy QueuePolicyPublic1 should not be public"
+        assert result.failed_rules[1].reason == "SQS Queue policy QueuePolicyPublic2 should not be public"
+        assert result.failed_rules[2].reason == "SQS Queue policy QueuePolicyPublic3 should not be public"
+        assert result.failed_rules[3].reason == "SQS Queue policy QueuePolicyPublic4 should not be public"
 
-        assert result.failed_rules[0]["risk_value"] == RuleRisk.HIGH
+        assert result.failed_rules[0].risk_value == RuleRisk.HIGH

--- a/tests/test_rules_sqs_policy_wildcard.py
+++ b/tests/test_rules_sqs_policy_wildcard.py
@@ -40,4 +40,4 @@ class TestSQSQueuePolicyWildcardActionRule:
         assert not result.valid
         assert len(result.failed_rules) == 4
         assert len(result.failed_monitored_rules) == 0
-        assert result.failed_rules[0]["reason"] == "SQS Queue policy mysqspolicy1 should not allow * action"
+        assert result.failed_rules[0].reason == "SQS Queue policy mysqspolicy1 should not allow * action"

--- a/tests/test_s3_cross_account.py
+++ b/tests/test_s3_cross_account.py
@@ -42,7 +42,7 @@ class TestS3CrossAccountTrustRule:
         assert len(result.failed_rules) == 1
         assert len(result.failed_monitored_rules) == 0
         assert (
-            result.failed_rules[0]["reason"]
+            result.failed_rules[0].reason
             == "S3BucketPolicyAccountAccess has forbidden cross-account policy allow with arn:aws:iam::987654321:root for an S3 bucket."
         )
 
@@ -65,6 +65,6 @@ class TestS3CrossAccountTrustRuleWithNormalAccess:
         assert len(result.failed_rules) == 1
         assert len(result.failed_monitored_rules) == 0
         assert (
-            result.failed_rules[0]["reason"]
+            result.failed_rules[0].reason
             == "S3BucketPolicyAccountAccess has forbidden cross-account policy allow with arn:aws:iam::666555444:root for an S3 bucket."
         )


### PR DESCRIPTION
Fix issue when calling CFRipper as a lambda.

It would fail due to sets not being serialized properly