### PR TITLE
Add valid as a property in Result class

### DIFF
--- a/cfripper/model/result.py
+++ b/cfripper/model/result.py
@@ -44,6 +44,7 @@ class Failure:
 class Result:
     """An object to represent scan results."""
 
+    valid: bool
     failed_rules: List[Failure] = field(default_factory=list)
     exceptions: List = field(default_factory=list)
     failed_monitored_rules: List[Failure] = field(default_factory=list)
@@ -90,3 +91,11 @@ class Result:
     @property
     def valid(self) -> bool:
         return not bool([rule for rule in self.failed_rules if rule.rule_mode == RuleMode.BLOCKING])
+
+    @valid.setter
+    def valid(self, value):
+        # This setter is required as otherwise the dataclass raises a "can't be set" exception on init
+        # due to valid being defined as a property
+        if isinstance(value, property):
+            return
+        raise Exception("Valid attribute can't be set")

--- a/cfripper/model/result.py
+++ b/cfripper/model/result.py
@@ -44,7 +44,6 @@ class Failure:
 class Result:
     """An object to represent scan results."""
 
-    valid: bool = True
     failed_rules: List[Failure] = field(default_factory=list)
     exceptions: List = field(default_factory=list)
     failed_monitored_rules: List[Failure] = field(default_factory=list)
@@ -74,9 +73,6 @@ class Result:
             self.add_failure_monitored_rule(failure=failure)
             return
 
-        if self.valid:
-            self.valid = False
-
         self.add_failure_blocking_rule(failure=failure)
 
     def add_exception(self, ex):
@@ -90,3 +86,7 @@ class Result:
 
     def add_failure_blocking_rule(self, failure: Failure):
         self.failed_rules.append(failure)
+
+    @property
+    def valid(self) -> bool:
+        return not bool([rule for rule in self.failed_rules if rule.rule_mode == RuleMode.BLOCKING])

--- a/tests/model/test_result.py
+++ b/tests/model/test_result.py
@@ -1,0 +1,19 @@
+from cfripper.model.enums import RuleGranularity, RuleMode, RuleRisk
+from cfripper.model.result import Result
+
+
+def test_result_valid_after_removing_failures():
+    result = Result()
+    result.add_failure(
+        rule="mock_rule",
+        reason="mock_reason",
+        rule_mode=RuleMode.BLOCKING,
+        risk_value=RuleRisk.HIGH,
+        granularity=RuleGranularity.STACK,
+    )
+    # Result has a blocking failure, so it should be invalid
+    assert result.valid is False
+
+    result.failed_rules = []
+    # Result has no failures, so it should be invalid
+    assert result.valid is True

--- a/tests/model/test_result.py
+++ b/tests/model/test_result.py
@@ -15,5 +15,5 @@ def test_result_valid_after_removing_failures():
     assert result.valid is False
 
     result.failed_rules = []
-    # Result has no failures, so it should be invalid
+    # Result has no failures, so it should be valid
     assert result.valid is True


### PR DESCRIPTION
## Context
The valid attribute was previously being updated as rules were added.
Now that we have resource whitelisting and we remove the failures after adding them this method of calculating valid doesn't work anymore.

## Changes
Update `valid` attribute to be a property, results are only valid if they don't have Blocking rules.
