### PR TITLE
Add AWS ELB service account whitelist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.10.1] - 2019-11-14
+## Added
+- New regexes and utility methods to get parts of arns
+### Changed
+- `S3CrossAccountTrustRule` and `S3BucketPolicyPrincipalRule` won't trigger if the principal comes from one of the AWS ELB service account ids
+
 ## [0.10.0] - 2019-11-08
 ### Added
 - New regex `REGEX_IS_STAR`, matches only a `*` character.

--- a/cfripper/config/config.py
+++ b/cfripper/config/config.py
@@ -15,6 +15,7 @@ specific language governing permissions and limitations under the License.
 import re
 from typing import List
 
+from .whitelist import AWS_ELB_ACCOUNT_IDS
 from .whitelist import rule_to_action_whitelist as default_rule_to_action_whitelist
 from .whitelist import rule_to_resource_whitelist as default_rule_to_resource_whitelist
 from .whitelist import stack_whitelist as default_stack_whitelist
@@ -94,6 +95,7 @@ class Config:
         aws_account_id=None,
         aws_user_agent=None,
         aws_principals=None,
+        aws_service_accounts=None,
         stack_whitelist=None,
         rule_to_action_whitelist=None,
         rule_to_resource_whitelist=None,
@@ -115,6 +117,7 @@ class Config:
             rule_to_resource_whitelist if rule_to_resource_whitelist is not None else default_rule_to_resource_whitelist
         )
         self.stack_whitelist = stack_whitelist if stack_whitelist is not None else default_stack_whitelist
+        self.aws_service_accounts = aws_service_accounts if aws_service_accounts is not None else AWS_ELB_ACCOUNT_IDS
 
         if self.stack_name:
             whitelisted_rules = self.get_whitelisted_rules()

--- a/cfripper/config/regex.py
+++ b/cfripper/config/regex.py
@@ -80,7 +80,7 @@ REGEX_IS_STAR = re.compile(r"^\*$")
 
 """
 Check for arns
-It has 3 groups. The first one for service name, the second one for region, the third, for account id, the last one
+It has 4 groups. The first one for service name, the second one for region, the third, for account id, the last one
 for resource id
 Valid:
 - arn:aws:iam::437628376:not-root
@@ -92,8 +92,8 @@ Invalid:
 REGEX_ARN = re.compile(r"^arn:aws:(\w+):(\w*):(\d*):(.+)$")
 
 """
-Check for arns
-It has 3 groups. The first one for account id, the last one  for resource id
+Check for iam arns
+It has 2 groups. The first one for account id, the last one  for resource id
 Valid:
 - arn:aws:iam::437628376:not-root
 Invalid:

--- a/cfripper/config/regex.py
+++ b/cfripper/config/regex.py
@@ -77,3 +77,27 @@ Invalid:
 - potato
 """
 REGEX_IS_STAR = re.compile(r"^\*$")
+
+"""
+Check for arns
+It has 3 groups. The first one for service name, the second one for region, the third, for account id, the last one
+for resource id
+Valid:
+- arn:aws:iam::437628376:not-root
+- arn:aws:iam::437628376:root
+- arn:aws:s3:::my_corporate_bucket
+Invalid:
+- potato
+"""
+REGEX_ARN = re.compile(r"^arn:aws:(\w+):(\w*):(\d*):(.+)$")
+
+"""
+Check for arns
+It has 3 groups. The first one for account id, the last one  for resource id
+Valid:
+- arn:aws:iam::437628376:not-root
+Invalid:
+- arn:aws:s3:::my_corporate_bucket
+- potato
+"""
+REGEX_IAM_ARN = re.compile(r"^arn:aws:iam::(\d*):(.*)$")

--- a/cfripper/config/whitelist.py
+++ b/cfripper/config/whitelist.py
@@ -102,3 +102,31 @@ rule_to_action_whitelist = {
 """
 
 rule_to_action_whitelist = {}
+
+
+AWS_ELB_ACCOUNT_IDS = [
+    # From https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-access-logs.html
+    "009996457667",  # Elastic Load Balancing Account ID - eu-west-3
+    "027434742980",  # Elastic Load Balancing Account ID - us-west-1
+    "033677994240",  # Elastic Load Balancing Account ID - us-east-2
+    "037604701340",  # Elastic Load Balancing Account ID - cn-northwest-1*
+    "048591011584",  # Elastic Load Balancing Account ID - us-gov-west-1*
+    "054676820928",  # Elastic Load Balancing Account ID - eu-central-1
+    "076674570225",  # Elastic Load Balancing Account ID - me-south-1
+    "114774131450",  # Elastic Load Balancing Account ID - ap-southeast-1
+    "127311923021",  # Elastic Load Balancing Account ID - us-east-1
+    "156460612806",  # Elastic Load Balancing Account ID - eu-west-1
+    "190560391635",  # Elastic Load Balancing Account ID - us-gov-east-1*
+    "383597477331",  # Elastic Load Balancing Account ID - ap-northeast-3
+    "507241528517",  # Elastic Load Balancing Account ID - sa-east-1
+    "582318560864",  # Elastic Load Balancing Account ID - ap-northeast-1
+    "600734575887",  # Elastic Load Balancing Account ID - ap-northeast-2
+    "638102146993",  # Elastic Load Balancing Account ID - cn-north-1*
+    "652711504416",  # Elastic Load Balancing Account ID - eu-west-2
+    "718504428378",  # Elastic Load Balancing Account ID - ap-south-1
+    "754344448648",  # Elastic Load Balancing Account ID - ap-east-1
+    "783225319266",  # Elastic Load Balancing Account ID - ap-southeast-2
+    "797873946194",  # Elastic Load Balancing Account ID - us-west-2
+    "897822967062",  # Elastic Load Balancing Account ID - eu-north-1
+    "985666609251",  # Elastic Load Balancing Account ID - ca-central-1
+]

--- a/cfripper/model/utils.py
+++ b/cfripper/model/utils.py
@@ -116,3 +116,9 @@ def get_account_id_from_iam_arn(arn) -> Optional[str]:
     match = REGEX_IAM_ARN.match(arn)
     if match:
         return match.group(1)
+
+
+def get_account_id_from_principal(principal: str) -> Optional[str]:
+    if principal.isnumeric():
+        return principal
+    return get_account_id_from_arn(principal)

--- a/cfripper/model/utils.py
+++ b/cfripper/model/utils.py
@@ -17,12 +17,15 @@ import logging
 import re
 from contextlib import suppress
 from functools import lru_cache
+from typing import Optional
 from urllib.parse import unquote
 
 import boto3
 import yaml
 from cfn_flip import to_json
 from pycfmodel.model.resources.properties.policy import Policy
+
+from cfripper.config.regex import REGEX_ARN, REGEX_IAM_ARN
 
 logger = logging.getLogger(__file__)
 
@@ -101,3 +104,15 @@ def get_managed_policy(managed_policy_arn):
             }
         )
     return None
+
+
+def get_account_id_from_arn(arn) -> Optional[str]:
+    match = REGEX_ARN.match(arn)
+    if match:
+        return match.group(3)
+
+
+def get_account_id_from_iam_arn(arn) -> Optional[str]:
+    match = REGEX_IAM_ARN.match(arn)
+    if match:
+        return match.group(1)

--- a/cfripper/model/utils.py
+++ b/cfripper/model/utils.py
@@ -106,13 +106,13 @@ def get_managed_policy(managed_policy_arn):
     return None
 
 
-def get_account_id_from_arn(arn) -> Optional[str]:
+def get_account_id_from_arn(arn: str) -> Optional[str]:
     match = REGEX_ARN.match(arn)
     if match:
         return match.group(3)
 
 
-def get_account_id_from_iam_arn(arn) -> Optional[str]:
+def get_account_id_from_iam_arn(arn: str) -> Optional[str]:
     match = REGEX_IAM_ARN.match(arn)
     if match:
         return match.group(1)
@@ -121,4 +121,4 @@ def get_account_id_from_iam_arn(arn) -> Optional[str]:
 def get_account_id_from_principal(principal: str) -> Optional[str]:
     if principal.isnumeric():
         return principal
-    return get_account_id_from_arn(principal)
+    return get_account_id_from_iam_arn(principal)

--- a/cfripper/rules/S3BucketPolicyPrincipalRule.py
+++ b/cfripper/rules/S3BucketPolicyPrincipalRule.py
@@ -16,7 +16,7 @@ import logging
 
 from pycfmodel.model.resources.s3_bucket_policy import S3BucketPolicy
 
-from cfripper.model.utils import get_account_id_from_iam_arn
+from cfripper.model.utils import get_account_id_from_principal
 
 from ..model.enums import RuleMode, RuleRisk
 from ..model.rule import Rule
@@ -36,7 +36,7 @@ class S3BucketPolicyPrincipalRule(Rule):
             if isinstance(resource, S3BucketPolicy):
                 for statement in resource.Properties.PolicyDocument._statement_as_list():
                     for principal in statement.get_principal_list():
-                        account_id = get_account_id_from_iam_arn(principal)
+                        account_id = get_account_id_from_principal(principal)
                         if not account_id:
                             continue
                         if account_id not in valid_principals:

--- a/cfripper/rules/S3CrossAccountTrustRule.py
+++ b/cfripper/rules/S3CrossAccountTrustRule.py
@@ -17,7 +17,7 @@ import logging
 from pycfmodel.model.resources.s3_bucket_policy import S3BucketPolicy
 
 from cfripper.model.enums import RuleMode
-from cfripper.model.utils import get_account_id_from_iam_arn
+from cfripper.model.utils import get_account_id_from_principal
 
 from ..model.rule import Rule
 
@@ -34,7 +34,7 @@ class S3CrossAccountTrustRule(Rule):
                 for statement in resource.Properties.PolicyDocument._statement_as_list():
                     if statement.Effect == "Allow":
                         for principal in statement.get_principal_list():
-                            account_id = get_account_id_from_iam_arn(principal)
+                            account_id = get_account_id_from_principal(principal)
                             if account_id in self._config.aws_service_accounts:
                                 # It's ok to allow access to AWS service accounts
                                 continue

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ dev_requires = [
 
 setup(
     name="cfripper",
-    version="0.10.0",
+    version="0.10.1",
     author="Skyscanner Product Security",
     author_email="security@skyscanner.net",
     long_description=long_description,

--- a/tests/config/test_regex.py
+++ b/tests/config/test_regex.py
@@ -15,9 +15,11 @@ specific language governing permissions and limitations under the License.
 import pytest
 
 from cfripper.config.regex import (
+    REGEX_ARN,
     REGEX_CONTAINS_STAR,
     REGEX_CROSS_ACCOUNT_ROOT,
     REGEX_FULL_WILDCARD_PRINCIPAL,
+    REGEX_IAM_ARN,
     REGEX_IS_STAR,
     REGEX_WILDCARD_POLICY_ACTION,
 )
@@ -53,6 +55,14 @@ from cfripper.config.regex import (
         (REGEX_IS_STAR, "*abcdef", False),
         (REGEX_IS_STAR, "arn:aws:iam::437628376:not-root", False),
         (REGEX_IS_STAR, "potato", False),
+        (REGEX_ARN, "arn:aws:iam::437628376:not-root", True),
+        (REGEX_ARN, "arn:aws:iam::437628376:root", True),
+        (REGEX_ARN, "arn:aws:s3:::my_corporate_bucket", True),
+        (REGEX_ARN, "potato", False),
+        (REGEX_IAM_ARN, "arn:aws:iam::437628376:not-root", True),
+        (REGEX_IAM_ARN, "arn:aws:iam::437628376:root", True),
+        (REGEX_IAM_ARN, "arn:aws:s3:::my_corporate_bucket", False),
+        (REGEX_IAM_ARN, "potato", False),
     ],
 )
 def test_regex_cross_account_root(regex, data, valid):

--- a/tests/rules/test_S3BucketPolicyPrincipalRule.py
+++ b/tests/rules/test_S3BucketPolicyPrincipalRule.py
@@ -31,7 +31,9 @@ def test_failures_are_raised(bad_template):
     rule.invoke(bad_template)
 
     assert not result.valid
-    assert len(result.failed_rules) == 1
+    assert len(result.failed_rules) == 2
     assert len(result.failed_monitored_rules) == 0
     assert result.failed_rules[0].rule == "S3BucketPolicyPrincipalRule"
     assert result.failed_rules[0].reason == "S3 Bucket S3BucketPolicy policy has non-whitelisted principals 1234556"
+    assert result.failed_rules[1].rule == "S3BucketPolicyPrincipalRule"
+    assert result.failed_rules[1].reason == "S3 Bucket S3BucketPolicy policy has non-whitelisted principals 1234557"

--- a/tests/rules/test_S3BucketPolicyPrincipalRule.py
+++ b/tests/rules/test_S3BucketPolicyPrincipalRule.py
@@ -34,6 +34,4 @@ def test_failures_are_raised(bad_template):
     assert len(result.failed_rules) == 1
     assert len(result.failed_monitored_rules) == 0
     assert result.failed_rules[0].rule == "S3BucketPolicyPrincipalRule"
-    assert (
-        result.failed_rules[0].reason == "S3 Bucket S3BucketPolicy policy has non-whitelisted principals 156460612806"
-    )
+    assert result.failed_rules[0].reason == "S3 Bucket S3BucketPolicy policy has non-whitelisted principals 1234556"

--- a/tests/rules/test_S3CrossAccountTrustRule.py
+++ b/tests/rules/test_S3CrossAccountTrustRule.py
@@ -12,7 +12,7 @@ under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-import pytest
+from pytest import fixture
 
 from cfripper.config.config import Config
 from cfripper.model.result import Result
@@ -20,12 +20,17 @@ from cfripper.rules.S3CrossAccountTrustRule import S3CrossAccountTrustRule
 from tests.utils import get_cfmodel_from
 
 
-@pytest.fixture()
+@fixture()
 def s3_bucket_cross_account():
     return get_cfmodel_from("rules/S3CrossAccountTrustRule/s3_bucket_cross_account.json").resolve()
 
 
-@pytest.fixture()
+@fixture()
+def s3_bucket_cross_account_from_aws_service():
+    return get_cfmodel_from("rules/S3CrossAccountTrustRule/s3_bucket_cross_account_from_aws_service.json").resolve()
+
+
+@fixture()
 def s3_bucket_cross_account_and_normal():
     return get_cfmodel_from("rules/S3CrossAccountTrustRule/s3_bucket_cross_account_and_normal.json").resolve()
 
@@ -58,3 +63,13 @@ def test_s3_bucket_cross_account_and_normal(s3_bucket_cross_account_and_normal):
         result.failed_rules[0].reason
         == "S3BucketPolicyAccountAccess has forbidden cross-account policy allow with arn:aws:iam::666555444:root for an S3 bucket."
     )
+
+
+def test_s3_bucket_cross_account_from_aws_service(s3_bucket_cross_account_from_aws_service):
+    result = Result()
+    rule = S3CrossAccountTrustRule(Config(aws_account_id="123456789"), result)
+    rule.invoke(s3_bucket_cross_account_from_aws_service)
+
+    assert result.valid
+    assert len(result.failed_rules) == 0
+    assert len(result.failed_monitored_rules) == 0

--- a/tests/test_templates/rules/S3BucketPolicyPrincipalRule/bad_template.json
+++ b/tests/test_templates/rules/S3BucketPolicyPrincipalRule/bad_template.json
@@ -34,7 +34,8 @@
               "Resource": "arn:aws:s3:::fakebucketfakebucket/*",
               "Principal": {
                 "AWS": [
-                  "arn:aws:iam::1234556:root"
+                  "arn:aws:iam::1234556:root",
+                  "1234557"
                 ]
               }
             }

--- a/tests/test_templates/rules/S3BucketPolicyPrincipalRule/bad_template.json
+++ b/tests/test_templates/rules/S3BucketPolicyPrincipalRule/bad_template.json
@@ -34,7 +34,7 @@
               "Resource": "arn:aws:s3:::fakebucketfakebucket/*",
               "Principal": {
                 "AWS": [
-                  "arn:aws:iam::156460612806:root"
+                  "arn:aws:iam::1234556:root"
                 ]
               }
             }

--- a/tests/test_templates/rules/S3CrossAccountTrustRule/s3_bucket_cross_account_from_aws_service.json
+++ b/tests/test_templates/rules/S3CrossAccountTrustRule/s3_bucket_cross_account_from_aws_service.json
@@ -1,0 +1,113 @@
+{
+  "Description": "Example S3 Bucket with put object permissions from sandbox (Designed to be ran in prod or tooling etc.)",
+  "Parameters": {
+    "AWSAccount": {
+      "Default": "sandbox",
+      "Description": "Which AWS Account?",
+      "AllowedValues": [
+        "sandbox",
+        "prod"
+      ],
+      "Type": "String"
+    },
+    "ProjectName": {
+      "Description": "Project Name",
+      "Type": "String"
+    },
+    "ContactEmail": {
+      "Default": "awsome@awesome.net",
+      "Description": "Contact Email",
+      "Type": "String"
+    },
+    "BucketPostFix": {
+      "Default": "test-x-account-write",
+      "Description": "Appended to company-<AWSAccount>- to create the bucket name",
+      "Type": "String"
+    }
+  },
+  "Outputs": {
+    "Bucket": {
+      "Value": "S3Bucket",
+      "Description": "Example S3 Bucket"
+    },
+    "BucketURN": {
+      "Value": "S3Bucket.DomainName",
+      "Description": "Example S3 Bucket URN"
+    }
+  },
+  "Resources": {
+    "S3Bucket": {
+      "Type": "AWS::S3::Bucket",
+      "Properties": {
+        "AccessControl": "PublicRead",
+        "BucketName": [
+          "-",
+          [
+            "company",
+            "AWSAccount",
+            "BucketPostFix"
+          ]
+        ],
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": [
+              "-",
+              [
+                "company",
+                "AWSAccount",
+                "BucketPostFix"
+              ]
+            ]
+          },
+          {
+            "Key": "Project",
+            "Value": "ProjectName"
+          },
+          {
+            "Key": "Contact",
+            "Value": "ContactEmail"
+          },
+          {
+            "Key": "StackName",
+            "Value": "AWS::StackName"
+          }
+        ]
+      }
+    },
+    "S3BucketPolicyAccountAccess": {
+      "Type": "AWS::S3::BucketPolicy",
+      "Properties": {
+        "Bucket": {
+          "Ref": "S3Bucket"
+        },
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "AllowAccessFromSandbox",
+              "Action": [
+                "s3:PutObject"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                "",
+                [
+                  "arn:aws:s3:::",
+                  "S3Bucket",
+                  "/*"
+                ]
+              ],
+              "Principal": {
+                "AWS": [
+                  "arn:aws:iam::156460612806:root"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "AWSTemplateFormatVersion": "2010-09-09"
+}


### PR DESCRIPTION
This PR adds ELB service accounts and makes sure S3 bucket rules don't trigger due to the inclusion of any of this accounts in a bucket policy