### PR TITLE
Add logging for case where AWS Account ID is not present in the config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.10.2] - 2019-11-19
+### Changed
+- `CrossAccountTrustRule` outputs warning log message if the AWS Account ID is not present in the config.
+
 ## [0.10.1] - 2019-11-14
-## Added
+### Added
 - New regexes and utility methods to get parts of arns
 ### Changed
 - `S3CrossAccountTrustRule` and `S3BucketPolicyPrincipalRule` won't trigger if the principal comes from one of the AWS ELB service account ids

--- a/cfripper/rules/CrossAccountTrustRule.py
+++ b/cfripper/rules/CrossAccountTrustRule.py
@@ -12,6 +12,7 @@ under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+import logging
 import re
 
 from pycfmodel.model.resources.iam_role import IAMRole
@@ -19,6 +20,8 @@ from pycfmodel.model.resources.iam_role import IAMRole
 from ..config.regex import REGEX_CROSS_ACCOUNT_ROOT
 from ..model.enums import RuleGranularity, RuleMode
 from ..model.rule import Rule
+
+logger = logging.getLogger(__file__)
 
 
 class CrossAccountTrustRule(Rule):
@@ -56,3 +59,8 @@ class CrossAccountTrustRule(Rule):
                                     self.REASON.format(logical_id, principal),
                                     resource_ids={logical_id},
                                 )
+                else:
+                    logger.warning(
+                        f"Not adding {type(self).__name__} failure in {logical_id} "
+                        f"because no AWS Account ID was found in the config."
+                    )

--- a/tests/rules/test_CrossAccountTrustRule.py
+++ b/tests/rules/test_CrossAccountTrustRule.py
@@ -12,6 +12,8 @@ under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+from unittest.mock import patch
+
 import pytest
 
 from cfripper.config.config import Config
@@ -161,7 +163,8 @@ def test_non_whitelisted_stacks_are_reported_normally(template_two_roles_dict, e
     assert result.failed_rules == expected_result_two_roles
 
 
-def test_service_is_not_blocked(template_valid_with_service):
+@patch("logging.Logger.warning")
+def test_service_is_not_blocked(mock_logger, template_valid_with_service):
     result = Result()
     rule = CrossAccountTrustRule(Config(), result)
     rule.invoke(template_valid_with_service)
@@ -169,3 +172,7 @@ def test_service_is_not_blocked(template_valid_with_service):
     assert result.valid
     assert len(result.failed_rules) == 0
     assert len(result.failed_monitored_rules) == 0
+
+    mock_logger.assert_called_with(
+        "Not adding CrossAccountTrustRule failure in LambdaRole because no AWS Account ID was found in the config."
+    )


### PR DESCRIPTION
# Context
We had no visibility on when an AWS Account ID was not set in the config (for whatever reason).

# Changes
Add a logging statement for when an account ID is not present in the config, which affects the ability of the `CrossAccountTrust` rule to run. Test for logging statement also added.