### PR TITLE
Add hardcoded password check for AWS RDS Clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.10.2] - 2019-11-19
+### Changed
+- `HardcodedRDSPasswordRule` updated to check for both RDS Clusters and RDS Instances, and reduce false positives on valid instances.
+
 ## [0.10.1] - 2019-11-14
 ## Added
 - New regexes and utility methods to get parts of arns

--- a/cfripper/rules/HardcodedRDSPasswordRule.py
+++ b/cfripper/rules/HardcodedRDSPasswordRule.py
@@ -19,13 +19,40 @@ from ..model.rule import Rule
 
 class HardcodedRDSPasswordRule(Rule):
 
-    REASON = "Default RDS password parameter or missing NoEcho for {}."
+    REASON = "Default RDS {} password parameter or missing NoEcho for {}."
 
     def invoke(self, cfmodel):
+        password_protected_clusters = []
+        instances_to_check = []
+
         for logical_id, resource in cfmodel.Resources.items():
+            # flag insecure RDS Clusters.
             if (
-                resource.Type == "AWS::RDS::DBInstance"
+                resource.Type == "AWS::RDS::DBCluster"
                 and resource.Properties.get("MasterUserPassword", Parameter.NO_ECHO_NO_DEFAULT)
                 != Parameter.NO_ECHO_NO_DEFAULT
             ):
-                self.add_failure(type(self).__name__, self.REASON.format(logical_id))
+                self.add_failure(type(self).__name__, self.REASON.format("Cluster", logical_id))
+                continue
+
+            # keep track of secure RDS Clusters.
+            if resource.Type == "AWS::RDS::DBCluster":
+                password_protected_clusters.append(logical_id)
+                continue
+
+            # keep track of RDS instances so they can be examined in the code below.
+            if resource.Type == "AWS::RDS::DBInstance":
+                instances_to_check.append((logical_id, resource))
+
+        # check each instance with the context of clusters.
+        for logical_id, resource in instances_to_check:
+            if resource.Properties.get("DBClusterIdentifier") and any(
+                id in resource.Properties.get("DBClusterIdentifier") for id in password_protected_clusters
+            ):
+                continue
+
+            if (
+                resource.Properties.get("MasterUserPassword", Parameter.NO_ECHO_NO_DEFAULT)
+                != Parameter.NO_ECHO_NO_DEFAULT
+            ):
+                self.add_failure(type(self).__name__, self.REASON.format("Instance", logical_id))

--- a/cfripper/rules/HardcodedRDSPasswordRule.py
+++ b/cfripper/rules/HardcodedRDSPasswordRule.py
@@ -22,7 +22,7 @@ class HardcodedRDSPasswordRule(Rule):
     REASON = "Default RDS {} password parameter or missing NoEcho for {}."
 
     def invoke(self, cfmodel):
-        password_protected_clusters = []
+        password_protected_cluster_ids = []
         instances_to_check = []
 
         for logical_id, resource in cfmodel.Resources.items():
@@ -37,7 +37,7 @@ class HardcodedRDSPasswordRule(Rule):
 
             # keep track of secure RDS Clusters.
             if resource.Type == "AWS::RDS::DBCluster":
-                password_protected_clusters.append(logical_id)
+                password_protected_cluster_ids.append(logical_id)
                 continue
 
             # keep track of RDS instances so they can be examined in the code below.
@@ -47,7 +47,8 @@ class HardcodedRDSPasswordRule(Rule):
         # check each instance with the context of clusters.
         for logical_id, resource in instances_to_check:
             if resource.Properties.get("DBClusterIdentifier") and any(
-                id in resource.Properties.get("DBClusterIdentifier") for id in password_protected_clusters
+                clutser_id in resource.Properties.get("DBClusterIdentifier")
+                for clutser_id in password_protected_cluster_ids
             ):
                 continue
 

--- a/tests/rules/test_HardcodedRDSPasswordRule.py
+++ b/tests/rules/test_HardcodedRDSPasswordRule.py
@@ -20,19 +20,85 @@ from tests.utils import get_cfmodel_from
 
 
 @pytest.fixture()
-def bad_template():
+def bad_template_instances():
     return get_cfmodel_from("rules/HardcodedRDSPasswordRule/bad_template.json").resolve()
 
 
-def test_failures_are_raised(bad_template):
+@pytest.fixture()
+def bad_template_clusters():
+    return get_cfmodel_from("rules/HardcodedRDSPasswordRule/bad_template_cluster.json").resolve()
+
+
+@pytest.fixture()
+def good_template_clusters_and_instances():
+    return get_cfmodel_from("rules/HardcodedRDSPasswordRule/rds_good_cluster_good_instances.json").resolve()
+
+
+@pytest.fixture()
+def bad_template_good_clusters_with_bad_instances():
+    return get_cfmodel_from("rules/HardcodedRDSPasswordRule/rds_good_cluster_bad_instances.json").resolve()
+
+
+@pytest.fixture()
+def bad_template_clusters_with_bad_instances():
+    return get_cfmodel_from("rules/HardcodedRDSPasswordRule/rds_good_cluster_bad_instances.json").resolve()
+
+
+def test_failures_are_raised_for_instances(bad_template_instances):
     result = Result()
     rule = HardcodedRDSPasswordRule(None, result)
-    rule.invoke(bad_template)
+    rule.invoke(bad_template_instances)
 
     assert not result.valid
     assert len(result.failed_rules) == 2
     assert len(result.failed_monitored_rules) == 0
     assert result.failed_rules[0].rule == "HardcodedRDSPasswordRule"
-    assert result.failed_rules[0].reason == "Default RDS password parameter or missing NoEcho for BadDb3."
+    assert result.failed_rules[0].reason == "Default RDS Instance password parameter or missing NoEcho for BadDb3."
     assert result.failed_rules[1].rule == "HardcodedRDSPasswordRule"
-    assert result.failed_rules[1].reason == "Default RDS password parameter or missing NoEcho for BadDb5."
+    assert result.failed_rules[1].reason == "Default RDS Instance password parameter or missing NoEcho for BadDb5."
+
+
+def test_failures_are_raised_for_clusters(bad_template_clusters):
+    result = Result()
+    rule = HardcodedRDSPasswordRule(None, result)
+    rule.invoke(bad_template_clusters)
+
+    assert not result.valid
+    assert len(result.failed_rules) == 1
+    assert len(result.failed_monitored_rules) == 0
+    assert result.failed_rules[0].rule == "HardcodedRDSPasswordRule"
+    assert result.failed_rules[0].reason == "Default RDS Cluster password parameter or missing NoEcho for BadCluster1."
+
+
+def test_passed_cluster_pw_protected(good_template_clusters_and_instances):
+    result = Result()
+    rule = HardcodedRDSPasswordRule(None, result)
+    rule.invoke(good_template_clusters_and_instances)
+
+    assert result.valid
+
+
+def test_failures_are_raised_for_instances_without_protected_clusters(bad_template_good_clusters_with_bad_instances):
+    result = Result()
+    rule = HardcodedRDSPasswordRule(None, result)
+    rule.invoke(bad_template_good_clusters_with_bad_instances)
+
+    assert not result.valid
+    assert len(result.failed_rules) == 1
+    assert len(result.failed_monitored_rules) == 0
+    assert result.failed_rules[0].rule == "HardcodedRDSPasswordRule"
+    assert result.failed_rules[0].reason == "Default RDS Instance password parameter or missing NoEcho for BadDb5."
+
+
+def test_failures_are_raised_for_bad_instances_and_bad_clusters(bad_template_clusters_with_bad_instances):
+    result = Result()
+    rule = HardcodedRDSPasswordRule(None, result)
+    rule.invoke(bad_template_clusters_with_bad_instances)
+
+    assert not result.valid
+    assert len(result.failed_rules) == 2
+    assert len(result.failed_monitored_rules) == 0
+    assert result.failed_rules[0].rule == "HardcodedRDSPasswordRule"
+    assert result.failed_rules[0].reason == "Default RDS Instance password parameter or missing NoEcho for BadDb33."
+    assert result.failed_rules[1].rule == "HardcodedRDSPasswordRule"
+    assert result.failed_rules[1].reason == "Default RDS Cluster password parameter or missing NoEcho for BadCluster99."

--- a/tests/rules/test_HardcodedRDSPasswordRule.py
+++ b/tests/rules/test_HardcodedRDSPasswordRule.py
@@ -41,7 +41,7 @@ def bad_template_good_clusters_with_bad_instances():
 
 @pytest.fixture()
 def bad_template_clusters_with_bad_instances():
-    return get_cfmodel_from("rules/HardcodedRDSPasswordRule/rds_good_cluster_bad_instances.json").resolve()
+    return get_cfmodel_from("rules/HardcodedRDSPasswordRule/bad_clusters_and_instances.json").resolve()
 
 
 def test_failures_are_raised_for_instances(bad_template_instances):
@@ -99,6 +99,6 @@ def test_failures_are_raised_for_bad_instances_and_bad_clusters(bad_template_clu
     assert len(result.failed_rules) == 2
     assert len(result.failed_monitored_rules) == 0
     assert result.failed_rules[0].rule == "HardcodedRDSPasswordRule"
-    assert result.failed_rules[0].reason == "Default RDS Instance password parameter or missing NoEcho for BadDb33."
+    assert result.failed_rules[0].reason == "Default RDS Cluster password parameter or missing NoEcho for BadCluster99."
     assert result.failed_rules[1].rule == "HardcodedRDSPasswordRule"
-    assert result.failed_rules[1].reason == "Default RDS Cluster password parameter or missing NoEcho for BadCluster99."
+    assert result.failed_rules[1].reason == "Default RDS Instance password parameter or missing NoEcho for BadDb33."

--- a/tests/test_templates/rules/HardcodedRDSPasswordRule/bad_clusters_and_instances.json
+++ b/tests/test_templates/rules/HardcodedRDSPasswordRule/bad_clusters_and_instances.json
@@ -1,0 +1,46 @@
+{
+  "Parameters": {
+    "Password": {
+      "Type": "String"
+    },
+    "Password2": {
+      "Type": "String",
+      "NoEcho": "true"
+    },
+    "Password3": {
+      "Type": "String",
+      "NoEcho": "true",
+      "Default": "test"
+    }
+  },
+  "Resources": {
+    "BadDb33": {
+      "Type": "AWS::RDS::DBInstance",
+      "Properties": {
+        "SourceDBInstanceIdentifier": "sampleDbInstance",
+        "MasterUserPassword": {
+          "Ref": "Password"
+        }
+      }
+    },
+    "UnknownDB": {
+      "Type": "AWS::RDS::DBInstance",
+      "Properties": {
+        "SourceDBInstanceIdentifier": "sampleDbInstance",
+        "MasterUserPassword": {
+          "Ref": "Password2"
+        }
+      }
+    },
+    "BadCluster99": {
+      "Type": "AWS::RDS::DBCluster",
+      "DeletionPolicy": "Snapshot",
+      "Properties": {
+        "Engine": "aurora-postgresql",
+        "MasterUserPassword": {
+          "Ref": "Password3"
+        }
+      }
+    }
+  }
+}

--- a/tests/test_templates/rules/HardcodedRDSPasswordRule/bad_template_cluster.json
+++ b/tests/test_templates/rules/HardcodedRDSPasswordRule/bad_template_cluster.json
@@ -1,0 +1,32 @@
+{
+  "Parameters": {
+    "ClusterPW": {
+      "Type": "String"
+    },
+    "Password2": {
+      "Type": "String",
+      "NoEcho": "true"
+    }
+  },
+  "Resources": {
+    "BadCluster1": {
+      "Type": "AWS::RDS::DBCluster",
+      "DeletionPolicy": "Snapshot",
+      "Properties": {
+        "Engine": "aurora-postgresql",
+        "MasterUserPassword": {
+          "Ref": "ClusterPW"
+        }
+      }
+    },
+    "BadDb4": {
+      "Type": "AWS::RDS::DBInstance",
+      "Properties": {
+        "SourceDBInstanceIdentifier": "sampleDbInstance",
+        "MasterUserPassword": {
+          "Ref": "Password2"
+        }
+      }
+    }
+  }
+}

--- a/tests/test_templates/rules/HardcodedRDSPasswordRule/rds_good_cluster_bad_instances.json
+++ b/tests/test_templates/rules/HardcodedRDSPasswordRule/rds_good_cluster_bad_instances.json
@@ -1,0 +1,34 @@
+{
+  "Parameters": {
+    "GoodClusterPW": {
+      "Type": "String",
+      "NoEcho": "true"
+    },
+    "Password3": {
+      "Type": "String",
+      "NoEcho": "true",
+      "Default": "test"
+    }
+  },
+  "Resources": {
+    "GoodCluster1": {
+      "Type": "AWS::RDS::DBCluster",
+      "DeletionPolicy": "Snapshot",
+      "Properties": {
+        "Engine": "aurora-postgresql",
+        "MasterUserPassword": {
+          "Ref": "GoodClusterPW"
+        }
+      }
+    },
+    "BadDb5": {
+      "Type": "AWS::RDS::DBInstance",
+      "Properties": {
+        "SourceDBInstanceIdentifier": "sampleDbInstance",
+        "MasterUserPassword": {
+          "Ref": "Password3"
+        }
+      }
+    }
+  }
+}

--- a/tests/test_templates/rules/HardcodedRDSPasswordRule/rds_good_cluster_bad_instances.json
+++ b/tests/test_templates/rules/HardcodedRDSPasswordRule/rds_good_cluster_bad_instances.json
@@ -21,6 +21,15 @@
         }
       }
     },
+    "GoodDb77": {
+      "Type": "AWS::RDS::DBInstance",
+      "Properties": {
+        "SourceDBInstanceIdentifier": "sampleDbInstance",
+        "DBClusterIdentifier": {
+          "Ref": "GoodCluster1"
+        }
+      }
+    },
     "BadDb5": {
       "Type": "AWS::RDS::DBInstance",
       "Properties": {

--- a/tests/test_templates/rules/HardcodedRDSPasswordRule/rds_good_cluster_good_instances.json
+++ b/tests/test_templates/rules/HardcodedRDSPasswordRule/rds_good_cluster_good_instances.json
@@ -1,0 +1,29 @@
+{
+  "Parameters": {
+    "GoodClusterPW": {
+      "Type": "String",
+      "NoEcho": "true"
+    }
+  },
+  "Resources": {
+    "GoodCluster1": {
+      "Type": "AWS::RDS::DBCluster",
+      "DeletionPolicy": "Snapshot",
+      "Properties": {
+        "Engine": "aurora-postgresql",
+        "MasterUserPassword": {
+          "Ref": "GoodClusterPW"
+        }
+      }
+    },
+    "DontCareDB": {
+      "Type": "AWS::RDS::DBInstance",
+      "Properties": {
+        "SourceDBInstanceIdentifier": "sampleDbInstance",
+        "DBClusterIdentifier": {
+          "Ref": "GoodCluster1"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Context

CFRipper will currently flag stacks as invalid when an RDS Instance is being created without a master password set or missing `NoEcho`. However, the rule does not take into consideration RDS Clusters being created with a correct password policy, and instances being part of that cluster. In those cases, the instances inherit the password policy from the cluster, and it is should be a valid CloudFormation file.

# Changes

- Update to `HardcodedRDSPasswordRule` to look at both Clusters and Instances for misconfigurations
- The rule now tracks clusters with passwords set correctly, and checks each instance to see if it is part of a protected cluster or not
- Tests added for each use case below:
  - 1x misconfigured RDS instance (invalid)
  - 1x misconfigured RDS cluster (invalid)
  - 1x protected RDS instance in 1x protected RDS cluster (valid)
  - 1x misconfigured RDS instance in same file as 1x protected cluster, but the instance is not part of the cluster (invalid)
  - 1x misconfigured RDS instance and 1x misconfigured cluster in the same CF file (although the instance and cluster are unrelated to each other) (invalid)
