### PR TITLE
Revert issue where S3CrossAccountTrustRule would accept whitelisted a…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,22 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.10.3] - 2019-11-20
+### Fixes
+- Fix a regression that caused `S3CrossAccountTrustRule` not to alert whenever cross-account permissions are found 
+within the allowed list of aws accounts.
+
 ## [0.10.2] - 2019-11-20
 ### Added
-- Added `PrincipalCheckingRule`, it has a property called `valid_principals`. It's a list with all allowed principals. This list can be customized using `_get_whitelist_from_config()`.
+- Added `PrincipalCheckingRule`, it has a property called `valid_principals`. It's a list with all allowed principals. 
+This list can be customized using `_get_whitelist_from_config()`.
 - Added `AWS_ELASTICACHE_BACKUP_CANONICAL_IDS` which contains the aws canonical ids used for backups.
 ### Changed
 - `CrossAccountTrustRule` outputs warning log message if the AWS Account ID is not present in the config.
-- `HardcodedRDSPasswordRule` updated to check for both RDS Clusters and RDS Instances, and reduce false positives on valid instances.
-- `CrossAccountTrustRule`, `GenericWildcardPrincipalRule`, `S3BucketPolicyPrincipalRule`, `S3BucketPolicyPrincipalRule` and `S3CrossAccountTrustRule` now check the account against a list.
+- `HardcodedRDSPasswordRule` updated to check for both RDS Clusters and RDS Instances, and reduce false positives on 
+valid instances.
+- `CrossAccountTrustRule`, `GenericWildcardPrincipalRule`, `S3BucketPolicyPrincipalRule`, `S3BucketPolicyPrincipalRule` 
+and `S3CrossAccountTrustRule` now check the account against a list.
   The list is composed of AWS service accounts, configured AWS principals and the account id where the event came from.
 - Rename `AWS_ELB_ACCOUNT_IDS` to `AWS_ELB_LOGS_ACCOUNT_IDS`
 
@@ -16,15 +24,18 @@ All notable changes to this project will be documented in this file.
 ### Added
 - New regexes and utility methods to get parts of arns
 ### Changed
-- `S3CrossAccountTrustRule` and `S3BucketPolicyPrincipalRule` won't trigger if the principal comes from one of the AWS ELB service account ids
+- `S3CrossAccountTrustRule` and `S3BucketPolicyPrincipalRule` won't trigger if the principal comes from one of the AWS 
+ELB service account ids
 
 ## [0.10.0] - 2019-11-08
 ### Added
 - New regex `REGEX_IS_STAR`, matches only a `*` character.
 
 ### Changed
-- `GenericWildcardPrincipalRule`, `S3BucketPolicyPrincipalRule`, `S3CrossAccountTrustRule`, `SQSQueuePolicyPublicRule` and `KMSKeyWildcardPrincipal` now trust the condition to reduce false positives.
-- Rules check the resource type using `isinstance` instead of comparing type to a string if pycfmodel implements the resource. 
+- `GenericWildcardPrincipalRule`, `S3BucketPolicyPrincipalRule`, `S3CrossAccountTrustRule`, `SQSQueuePolicyPublicRule` 
+and `KMSKeyWildcardPrincipal` now trust the condition to reduce false positives.
+- Rules check the resource type using `isinstance` instead of comparing type to a string if pycfmodel implements the 
+resource. 
 - Instance method `add_failure` now accepts `risk_value` and `risk_mode` as optional parameters. 
 - `CrossAccountTrustRule` only runs if config has defined `self._config.aws_account_id`.
 - `IAMRoleWildcardActionOnPermissionsPolicyRule`now uses `REGEX_WILDCARD_POLICY_ACTION`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [0.10.3] - 2019-11-20
+## [0.11.0] - 2019-11-20
+### Breaking changes
+- Moved some files from model to rules, renamed rules to match pythonic style
 ### Fixes
-- Fix a regression that caused `S3CrossAccountTrustRule` not to alert whenever cross-account permissions are found 
-within the allowed list of aws accounts.
+- Fix a regression that caused `S3CrossAccountTrustRule` and `CrossAccountTrustRule` not to alert whenever 
+cross-account permissions are found within the allowed list of aws accounts.
 
 ## [0.10.2] - 2019-11-20
 ### Added

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Be sure to also add them in the `scripts` dictionary with their name, service na
 
 ## Custom Rules
 
-To add custom rules first extend the [Rule](cfripper/model/rule_processor.py) class. Then implement the `invoke` method by adding your logic.
+To add custom rules first extend the [Rule](cfripper/rule_processor.py) class. Then implement the `invoke` method by adding your logic.
 
 CFripper uses [pycfmodel](https://github.com/Skyscanner/pycfmodel) to create a Python model of the CloudFormation script. This model is passed to the `invoke` function as the `resources` parameter. You can use the model's iterate through the resources and other objects of the model and use the helper functions to perform various checks. Look at the [current rules](cfripper/rules) for examples.
 

--- a/cfripper/main.py
+++ b/cfripper/main.py
@@ -17,11 +17,12 @@ import logging
 
 import pycfmodel
 
+from cfripper.rule_processor import RuleProcessor
+
 from .boto3_client import Boto3Client
 from .config.config import Config
 from .config.logger import setup_logging
 from .model.result import Result
-from .model.rule_processor import RuleProcessor
 from .rules import DEFAULT_RULES
 
 logger = logging.getLogger(__file__)

--- a/cfripper/rule_processor.py
+++ b/cfripper/rule_processor.py
@@ -16,9 +16,9 @@ import logging
 import re
 from typing import List
 
-from ..config.config import Config
-from .enums import RuleGranularity, RuleMode
-from .result import Failure, Result
+from cfripper.config.config import Config
+from cfripper.model.enums import RuleGranularity, RuleMode
+from cfripper.model.result import Failure, Result
 
 logger = logging.getLogger(__file__)
 

--- a/cfripper/rules/CrossAccountTrustRule.py
+++ b/cfripper/rules/CrossAccountTrustRule.py
@@ -17,11 +17,10 @@ import re
 
 from pycfmodel.model.resources.iam_role import IAMRole
 
-from cfripper.model.utils import get_account_id_from_principal
 from cfripper.rules.base_rules import CrossAccountCheckingRule
 
 from ..config.regex import REGEX_CROSS_ACCOUNT_ROOT
-from ..model.enums import RuleGranularity, RuleMode
+from ..model.enums import RuleGranularity
 
 logger = logging.getLogger(__file__)
 

--- a/cfripper/rules/CrossAccountTrustRule.py
+++ b/cfripper/rules/CrossAccountTrustRule.py
@@ -17,7 +17,8 @@ import re
 
 from pycfmodel.model.resources.iam_role import IAMRole
 
-from cfripper.rules.base_rules import PrincipalCheckingRule
+from cfripper.model.utils import get_account_id_from_principal
+from cfripper.rules.base_rules import CrossAccountCheckingRule
 
 from ..config.regex import REGEX_CROSS_ACCOUNT_ROOT
 from ..model.enums import RuleGranularity, RuleMode
@@ -25,22 +26,18 @@ from ..model.enums import RuleGranularity, RuleMode
 logger = logging.getLogger(__file__)
 
 
-class CrossAccountTrustRule(PrincipalCheckingRule):
+class CrossAccountTrustRule(CrossAccountCheckingRule):
 
     REASON = "{} has forbidden cross-account trust relationship with {}"
     ROOT_PATTERN = re.compile(REGEX_CROSS_ACCOUNT_ROOT)
     GRANULARITY = RuleGranularity.RESOURCE
 
-    def invoke(self, cfmodel):
+    def invoke_old(self, cfmodel):
         not_has_account_id = re.compile(rf"^((?!{self._config.aws_account_id}).)*$")
         for logical_id, resource in cfmodel.Resources.items():
             if isinstance(resource, IAMRole):
-                for principal in resource.Properties.AssumeRolePolicyDocument.allowed_principals_with(
-                    self.ROOT_PATTERN
-                ):
-                    self.add_failure(
-                        type(self).__name__, self.REASON.format(logical_id, principal), resource_ids={logical_id}
-                    )
+
+                self._detect_cross_account_root_principals(logical_id, resource)
 
                 if self._config.aws_account_id:
                     for principal in resource.Properties.AssumeRolePolicyDocument.allowed_principals_with(
@@ -67,3 +64,17 @@ class CrossAccountTrustRule(PrincipalCheckingRule):
                         f"Not adding {type(self).__name__} failure in {logical_id} "
                         f"because no AWS Account ID was found in the config."
                     )
+
+    def _detect_cross_account_root_principals(self, logical_id, resource):
+        for principal in resource.Properties.AssumeRolePolicyDocument.allowed_principals_with(self.ROOT_PATTERN):
+            account_id = get_account_id_from_principal(principal)
+            if account_id not in self.valid_principals:
+                self.add_failure(
+                    type(self).__name__, self.REASON.format(logical_id, principal), resource_ids={logical_id}
+                )
+
+    def invoke(self, cfmodel):
+        for logical_id, resource in cfmodel.Resources.items():
+            if isinstance(resource, IAMRole):
+                for statement in resource.Properties.AssumeRolePolicyDocument._statement_as_list():
+                    self._do_statement_check(logical_id, statement)

--- a/cfripper/rules/CrossAccountTrustRule.py
+++ b/cfripper/rules/CrossAccountTrustRule.py
@@ -17,9 +17,10 @@ import re
 
 from pycfmodel.model.resources.iam_role import IAMRole
 
+from cfripper.rules.base_rules import PrincipalCheckingRule
+
 from ..config.regex import REGEX_CROSS_ACCOUNT_ROOT
 from ..model.enums import RuleGranularity, RuleMode
-from ..model.principal_checking_rule import PrincipalCheckingRule
 
 logger = logging.getLogger(__file__)
 

--- a/cfripper/rules/GenericWildcardPrincipalRule.py
+++ b/cfripper/rules/GenericWildcardPrincipalRule.py
@@ -25,8 +25,9 @@ from pycfmodel.model.resources.s3_bucket_policy import S3BucketPolicy
 from pycfmodel.model.resources.sns_topic_policy import SNSTopicPolicy
 from pycfmodel.model.resources.sqs_queue_policy import SQSQueuePolicy
 
+from cfripper.rules.base_rules import PrincipalCheckingRule
+
 from ..model.enums import RuleMode
-from ..model.principal_checking_rule import PrincipalCheckingRule
 
 logger = logging.getLogger(__file__)
 

--- a/cfripper/rules/S3BucketPolicyPrincipalRule.py
+++ b/cfripper/rules/S3BucketPolicyPrincipalRule.py
@@ -17,9 +17,9 @@ import logging
 from pycfmodel.model.resources.s3_bucket_policy import S3BucketPolicy
 
 from cfripper.model.utils import get_account_id_from_principal
+from cfripper.rules.base_rules import PrincipalCheckingRule
 
 from ..model.enums import RuleMode, RuleRisk
-from ..model.principal_checking_rule import PrincipalCheckingRule
 
 logger = logging.getLogger(__file__)
 

--- a/cfripper/rules/S3CrossAccountTrustRule.py
+++ b/cfripper/rules/S3CrossAccountTrustRule.py
@@ -13,13 +13,13 @@ CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
 import logging
+from typing import Set
 
 from pycfmodel.model.resources.s3_bucket_policy import S3BucketPolicy
 
 from cfripper.model.enums import RuleMode
 from cfripper.model.utils import get_account_id_from_principal
-
-from ..model.principal_checking_rule import PrincipalCheckingRule
+from cfripper.rules.base_rules import PrincipalCheckingRule
 
 logger = logging.getLogger(__file__)
 
@@ -27,6 +27,15 @@ logger = logging.getLogger(__file__)
 class S3CrossAccountTrustRule(PrincipalCheckingRule):
 
     REASON = "{} has forbidden cross-account policy allow with {} for an S3 bucket."
+
+    @property
+    def valid_principals(self) -> Set[str]:
+        if self._valid_principals is None:
+            self._valid_principals = {
+                self._config.aws_account_id,
+                *self._get_whitelist_from_config(),
+            }
+        return self._valid_principals
 
     def invoke(self, cfmodel):
         for logical_id, resource in cfmodel.Resources.items():

--- a/cfripper/rules/S3CrossAccountTrustRule.py
+++ b/cfripper/rules/S3CrossAccountTrustRule.py
@@ -13,48 +13,20 @@ CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
 import logging
-from typing import Set
 
 from pycfmodel.model.resources.s3_bucket_policy import S3BucketPolicy
 
-from cfripper.model.enums import RuleMode
-from cfripper.model.utils import get_account_id_from_principal
-from cfripper.rules.base_rules import PrincipalCheckingRule
+from cfripper.rules.base_rules import CrossAccountCheckingRule
 
 logger = logging.getLogger(__file__)
 
 
-class S3CrossAccountTrustRule(PrincipalCheckingRule):
+class S3CrossAccountTrustRule(CrossAccountCheckingRule):
 
     REASON = "{} has forbidden cross-account policy allow with {} for an S3 bucket."
-
-    @property
-    def valid_principals(self) -> Set[str]:
-        if self._valid_principals is None:
-            self._valid_principals = {
-                self._config.aws_account_id,
-                *self._get_whitelist_from_config(),
-            }
-        return self._valid_principals
 
     def invoke(self, cfmodel):
         for logical_id, resource in cfmodel.Resources.items():
             if isinstance(resource, S3BucketPolicy):
                 for statement in resource.Properties.PolicyDocument._statement_as_list():
-                    if statement.Effect == "Allow":
-                        for principal in statement.get_principal_list():
-                            account_id = get_account_id_from_principal(principal)
-                            if account_id not in self.valid_principals:
-                                if statement.Condition and statement.Condition.dict():
-                                    logger.warning(
-                                        f"Not adding {type(self).__name__} failure in {logical_id} "
-                                        f"because there are conditions: {statement.Condition}"
-                                    )
-                                elif "GETATT" in principal or "UNDEFINED_" in principal:
-                                    self.add_failure(
-                                        type(self).__name__,
-                                        self.REASON.format(logical_id, principal),
-                                        rule_mode=RuleMode.DEBUG,
-                                    )
-                                else:
-                                    self.add_failure(type(self).__name__, self.REASON.format(logical_id, principal))
+                    self._do_statement_check(logical_id, statement)

--- a/cfripper/rules/base_rules.py
+++ b/cfripper/rules/base_rules.py
@@ -18,9 +18,7 @@ from cfripper.model.rule import Rule
 
 
 class PrincipalCheckingRule(Rule):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._valid_principals = None
+    _valid_principals = None
 
     def _get_whitelist_from_config(self, services: List[str] = None) -> Set[str]:
         if services is None:

--- a/cfripper/rules/base_rules.py
+++ b/cfripper/rules/base_rules.py
@@ -12,9 +12,14 @@ under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+import logging
 from typing import List, Set
 
+from cfripper.model.enums import RuleMode
 from cfripper.model.rule import Rule
+from cfripper.model.utils import get_account_id_from_principal
+
+logger = logging.getLogger(__file__)
 
 
 class PrincipalCheckingRule(Rule):
@@ -34,7 +39,46 @@ class PrincipalCheckingRule(Rule):
         if self._valid_principals is None:
             self._valid_principals = {
                 *self._config.aws_principals,
-                self._config.aws_account_id,
                 *self._get_whitelist_from_config(),
             }
+            if self._config.aws_account_id:
+                self._valid_principals.add(self._config.aws_account_id)
         return self._valid_principals
+
+
+class CrossAccountCheckingRule(PrincipalCheckingRule):
+    @property
+    def valid_principals(self) -> Set[str]:
+        if self._valid_principals is None:
+            self._valid_principals = self._get_whitelist_from_config()
+            if self._config.aws_account_id:
+                self._valid_principals.add(self._config.aws_account_id)
+        return self._valid_principals
+
+    def _do_statement_check(self, logical_id, statement):
+
+        if statement.Effect == "Allow":
+            for principal in statement.get_principal_list():
+                account_id = get_account_id_from_principal(principal)
+                if account_id not in self.valid_principals:
+                    if statement.Condition and statement.Condition.dict():
+                        logger.warning(
+                            f"Not adding {type(self).__name__} failure in {logical_id} "
+                            f"because there are conditions: {statement.Condition}"
+                        )
+                    elif not self._config.aws_account_id:
+                        logger.warning(
+                            f"Not adding {type(self).__name__} failure in {logical_id} "
+                            f"because no AWS Account ID was found in the config."
+                        )
+                    elif "GETATT" in principal or "UNDEFINED_" in principal:
+                        self.add_failure(
+                            type(self).__name__,
+                            self.REASON.format(logical_id, principal),
+                            rule_mode=RuleMode.DEBUG,
+                            resource_ids={logical_id},
+                        )
+                    else:
+                        self.add_failure(
+                            type(self).__name__, self.REASON.format(logical_id, principal), resource_ids={logical_id}
+                        )

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ dev_requires = [
 
 setup(
     name="cfripper",
-    version="0.10.2",
+    version="0.10.3",
     author="Skyscanner Product Security",
     author_email="security@skyscanner.net",
     long_description=long_description,

--- a/tests/model/test_principal_checking_rule.py
+++ b/tests/model/test_principal_checking_rule.py
@@ -16,8 +16,8 @@ import pytest
 from pycfmodel.model.cf_model import CFModel
 
 from cfripper.config.config import Config
-from cfripper.model.principal_checking_rule import PrincipalCheckingRule
 from cfripper.model.result import Result
+from cfripper.rules.base_rules import PrincipalCheckingRule
 
 
 class FakePrincipalCheckingRule(PrincipalCheckingRule):

--- a/tests/model/test_rule_processor.py
+++ b/tests/model/test_rule_processor.py
@@ -20,7 +20,7 @@ from pytest import fixture
 from cfripper.config.config import Config
 from cfripper.model.enums import RuleGranularity, RuleMode, RuleRisk
 from cfripper.model.result import Failure, Result
-from cfripper.model.rule_processor import RuleProcessor
+from cfripper.rule_processor import RuleProcessor
 from tests.utils import get_fixture_json
 
 
@@ -138,7 +138,7 @@ def test_remove_failures_from_whitelisted_resources_uses_whitelist(mock_rule_to_
     ]
 
 
-@patch("cfripper.model.rule_processor.logger.warning")
+@patch("cfripper.rule_processor.logger.warning")
 def test_remove_failures_from_whitelisted_resources_failure_no_resources_is_removed(
     mock_logger, mock_rule_to_resource_whitelist
 ):
@@ -326,7 +326,7 @@ def test_remove_failures_from_whitelisted_actions_uses_whitelist(mock_rule_to_ac
     ]
 
 
-@patch("cfripper.model.rule_processor.logger.warning")
+@patch("cfripper.rule_processor.logger.warning")
 def test_remove_failures_from_whitelisted_actions_failure_no_actions_is_removed(
     mock_logger, mock_rule_to_action_whitelist
 ):

--- a/tests/rules/test_S3CrossAccountTrustRule.py
+++ b/tests/rules/test_S3CrossAccountTrustRule.py
@@ -45,8 +45,8 @@ def test_s3_bucket_cross_account(s3_bucket_cross_account):
     assert len(result.failed_monitored_rules) == 0
     assert result.failed_rules[0].rule == "S3CrossAccountTrustRule"
     assert (
-        result.failed_rules[0].reason
-        == "S3BucketPolicyAccountAccess has forbidden cross-account policy allow with arn:aws:iam::987654321:root for an S3 bucket."
+        result.failed_rules[0].reason == "S3BucketPolicyAccountAccess has forbidden cross-account policy allow with "
+        "arn:aws:iam::987654321:root for an S3 bucket."
     )
 
 
@@ -60,9 +60,32 @@ def test_s3_bucket_cross_account_and_normal(s3_bucket_cross_account_and_normal):
     assert len(result.failed_monitored_rules) == 0
     assert result.failed_rules[0].rule == "S3CrossAccountTrustRule"
     assert (
-        result.failed_rules[0].reason
-        == "S3BucketPolicyAccountAccess has forbidden cross-account policy allow with arn:aws:iam::666555444:root for an S3 bucket."
+        result.failed_rules[0].reason == "S3BucketPolicyAccountAccess has forbidden cross-account policy allow with "
+        "arn:aws:iam::666555444:root for an S3 bucket."
     )
+
+
+def test_s3_bucket_cross_account_and_normal_with_org_aws_account(s3_bucket_cross_account_and_normal):
+    result = Result()
+    rule = S3CrossAccountTrustRule(Config(aws_account_id="123456789", aws_principals=["666555444"]), result)
+    rule.invoke(s3_bucket_cross_account_and_normal)
+
+    assert not result.valid
+    assert len(result.failed_rules) == 1
+    assert len(result.failed_monitored_rules) == 0
+    assert result.failed_rules[0].rule == "S3CrossAccountTrustRule"
+    assert (
+        result.failed_rules[0].reason == "S3BucketPolicyAccountAccess has forbidden cross-account policy allow with "
+        "arn:aws:iam::666555444:root for an S3 bucket."
+    )
+
+
+def test_s3_bucket_cross_account_for_current_account(s3_bucket_cross_account):
+    result = Result()
+    rule = S3CrossAccountTrustRule(Config(aws_account_id="987654321"), result)
+    rule.invoke(s3_bucket_cross_account)
+
+    assert result.valid
 
 
 def test_s3_bucket_cross_account_from_aws_service(s3_bucket_cross_account_from_aws_service):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -22,8 +22,8 @@ from moto import mock_s3
 from cfripper.config.config import Config
 from cfripper.main import handler
 from cfripper.model.result import Result
-from cfripper.model.rule_processor import RuleProcessor
 from cfripper.model.utils import convert_json_or_yaml_to_dict
+from cfripper.rule_processor import RuleProcessor
 from cfripper.rules import DEFAULT_RULES
 from tests.utils import get_templates
 


### PR DESCRIPTION
Fix a regression that caused `S3CrossAccountTrustRule` not to alert whenever cross-account permissions are found within the allowed list of aws accounts.