### PR TITLE
Fix harcoded password rds rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.11.1] - 2019-11-25
+### Changed
+- `HardcodedRDSPasswordRule` now reports two different messages when there is a missing echo or a readable password.
+### Fixes
+- `HardcodedRDSPasswordRule` was wrongly adding an error when a value is provided.
+
 ## [0.11.0] - 2019-11-20
 ### Breaking changes
 - Moved some files from model to rules, renamed rules to match pythonic style. Moved tons of classes around

--- a/cfripper/rules/hardcoded_RDS_password.py
+++ b/cfripper/rules/hardcoded_RDS_password.py
@@ -19,7 +19,7 @@ from ..model.rule import Rule
 
 class HardcodedRDSPasswordRule(Rule):
 
-    REASON_DEFAULT = "Default RDS {} password parameter (readable in plain-text) {}."
+    REASON_DEFAULT = "Default RDS {} password parameter (readable in plain-text) for {}."
     REASON_MISSING_NOECHO = "RDS {} password parameter missing NoEcho for {}."
 
     def invoke(self, cfmodel):
@@ -53,7 +53,7 @@ class HardcodedRDSPasswordRule(Rule):
         if master_user_password == Parameter.NO_ECHO_WITH_DEFAULT:
             self.add_failure(type(self).__name__, self.REASON_DEFAULT.format(resource_type, logical_id))
             return True
-        elif master_user_password not in (Parameter.NO_ECHO_NO_DEFAULT, Parameter.NO_ECHO_WITH_VALUE,):
+        elif master_user_password not in (Parameter.NO_ECHO_NO_DEFAULT, Parameter.NO_ECHO_WITH_VALUE):
             self.add_failure(type(self).__name__, self.REASON_MISSING_NOECHO.format(resource_type, logical_id))
             return True
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-install_requires = ["boto3>=1.4.7,<2", "PyYAML>=4.2b1", "pycfmodel>=0.5.0", "cfn_flip>=1.2.0"]
+install_requires = ["boto3>=1.4.7,<2", "PyYAML>=4.2b1", "pycfmodel>=0.5.1", "cfn_flip>=1.2.0"]
 
 dev_requires = [
     "black==19.10b0",
@@ -17,7 +17,7 @@ dev_requires = [
 
 setup(
     name="cfripper",
-    version="0.11.0",
+    version="0.11.1",
     author="Skyscanner Product Security",
     author_email="security@skyscanner.net",
     long_description=long_description,

--- a/tests/rules/test_HardcodedRDSPasswordRule.py
+++ b/tests/rules/test_HardcodedRDSPasswordRule.py
@@ -13,8 +13,11 @@ CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
 import pytest
+from pycfmodel.model.cf_model import CFModel
 
+from cfripper.config.config import Config
 from cfripper.model.result import Result
+from cfripper.model.utils import convert_json_or_yaml_to_dict
 from cfripper.rules.hardcoded_RDS_password import HardcodedRDSPasswordRule
 from tests.utils import get_cfmodel_from
 
@@ -53,9 +56,9 @@ def test_failures_are_raised_for_instances(bad_template_instances):
     assert len(result.failed_rules) == 2
     assert len(result.failed_monitored_rules) == 0
     assert result.failed_rules[0].rule == "HardcodedRDSPasswordRule"
-    assert result.failed_rules[0].reason == "Default RDS Instance password parameter or missing NoEcho for BadDb3."
+    assert result.failed_rules[0].reason == "RDS Instance password parameter missing NoEcho for BadDb3."
     assert result.failed_rules[1].rule == "HardcodedRDSPasswordRule"
-    assert result.failed_rules[1].reason == "Default RDS Instance password parameter or missing NoEcho for BadDb5."
+    assert result.failed_rules[1].reason == "Default RDS Instance password parameter (readable in plain-text) BadDb5."
 
 
 def test_failures_are_raised_for_clusters(bad_template_clusters):
@@ -67,7 +70,7 @@ def test_failures_are_raised_for_clusters(bad_template_clusters):
     assert len(result.failed_rules) == 1
     assert len(result.failed_monitored_rules) == 0
     assert result.failed_rules[0].rule == "HardcodedRDSPasswordRule"
-    assert result.failed_rules[0].reason == "Default RDS Cluster password parameter or missing NoEcho for BadCluster1."
+    assert result.failed_rules[0].reason == "RDS Cluster password parameter missing NoEcho for BadCluster1."
 
 
 def test_passed_cluster_pw_protected(good_template_clusters_and_instances):
@@ -87,7 +90,7 @@ def test_failures_are_raised_for_instances_without_protected_clusters(bad_templa
     assert len(result.failed_rules) == 1
     assert len(result.failed_monitored_rules) == 0
     assert result.failed_rules[0].rule == "HardcodedRDSPasswordRule"
-    assert result.failed_rules[0].reason == "Default RDS Instance password parameter or missing NoEcho for BadDb5."
+    assert result.failed_rules[0].reason == "Default RDS Instance password parameter (readable in plain-text) BadDb5."
 
 
 def test_failures_are_raised_for_bad_instances_and_bad_clusters(bad_template_clusters_with_bad_instances):
@@ -99,6 +102,8 @@ def test_failures_are_raised_for_bad_instances_and_bad_clusters(bad_template_clu
     assert len(result.failed_rules) == 2
     assert len(result.failed_monitored_rules) == 0
     assert result.failed_rules[0].rule == "HardcodedRDSPasswordRule"
-    assert result.failed_rules[0].reason == "Default RDS Cluster password parameter or missing NoEcho for BadCluster99."
+    assert (
+        result.failed_rules[0].reason == "Default RDS Cluster password parameter (readable in plain-text) BadCluster99."
+    )
     assert result.failed_rules[1].rule == "HardcodedRDSPasswordRule"
-    assert result.failed_rules[1].reason == "Default RDS Instance password parameter or missing NoEcho for BadDb33."
+    assert result.failed_rules[1].reason == "RDS Instance password parameter missing NoEcho for BadDb33."

--- a/tests/rules/test_HardcodedRDSPasswordRule.py
+++ b/tests/rules/test_HardcodedRDSPasswordRule.py
@@ -13,11 +13,8 @@ CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
 import pytest
-from pycfmodel.model.cf_model import CFModel
 
-from cfripper.config.config import Config
 from cfripper.model.result import Result
-from cfripper.model.utils import convert_json_or_yaml_to_dict
 from cfripper.rules.hardcoded_RDS_password import HardcodedRDSPasswordRule
 from tests.utils import get_cfmodel_from
 
@@ -58,7 +55,9 @@ def test_failures_are_raised_for_instances(bad_template_instances):
     assert result.failed_rules[0].rule == "HardcodedRDSPasswordRule"
     assert result.failed_rules[0].reason == "RDS Instance password parameter missing NoEcho for BadDb3."
     assert result.failed_rules[1].rule == "HardcodedRDSPasswordRule"
-    assert result.failed_rules[1].reason == "Default RDS Instance password parameter (readable in plain-text) BadDb5."
+    assert (
+        result.failed_rules[1].reason == "Default RDS Instance password parameter (readable in plain-text) for BadDb5."
+    )
 
 
 def test_failures_are_raised_for_clusters(bad_template_clusters):
@@ -90,7 +89,9 @@ def test_failures_are_raised_for_instances_without_protected_clusters(bad_templa
     assert len(result.failed_rules) == 1
     assert len(result.failed_monitored_rules) == 0
     assert result.failed_rules[0].rule == "HardcodedRDSPasswordRule"
-    assert result.failed_rules[0].reason == "Default RDS Instance password parameter (readable in plain-text) BadDb5."
+    assert (
+        result.failed_rules[0].reason == "Default RDS Instance password parameter (readable in plain-text) for BadDb5."
+    )
 
 
 def test_failures_are_raised_for_bad_instances_and_bad_clusters(bad_template_clusters_with_bad_instances):
@@ -103,7 +104,8 @@ def test_failures_are_raised_for_bad_instances_and_bad_clusters(bad_template_clu
     assert len(result.failed_monitored_rules) == 0
     assert result.failed_rules[0].rule == "HardcodedRDSPasswordRule"
     assert (
-        result.failed_rules[0].reason == "Default RDS Cluster password parameter (readable in plain-text) BadCluster99."
+        result.failed_rules[0].reason
+        == "Default RDS Cluster password parameter (readable in plain-text) for BadCluster99."
     )
     assert result.failed_rules[1].rule == "HardcodedRDSPasswordRule"
     assert result.failed_rules[1].reason == "RDS Instance password parameter missing NoEcho for BadDb33."


### PR DESCRIPTION
### Changed
- `HardcodedRDSPasswordRule` now reports two different messages when there is a missing echo or a readable password.
### Fixes
- `HardcodedRDSPasswordRule` was wrongly adding an error when a value is provided.