### PR TITLE
Fix tabs inside YML templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.11.X] - 2019-11-?? UNRELEASED
+### Fixes
+- Substitute tabs for spaces till is not considered a valid template by Cloudformation service.
+
 ## [0.11.2] - 2019-11-26
 ### Fixes
 - Fix `get_template` when AWS doesn't return a dict.

--- a/cfripper/model/utils.py
+++ b/cfripper/model/utils.py
@@ -86,7 +86,10 @@ def replace_tabs(content: str, new_chars: str = "  ") -> str:
 
 def convert_json_or_yaml_to_dict(file_content):
     # BEGIN OF FIX
-    # Details at: https://github.com/awslabs/aws-cfn-template-flip/issues/87
+    # AWS Cloudformation service accepts YML templates that contain tab characters. This is not compliant.
+    # But CFRipper is going to accept those templates because are also accepted by Cloudformation service.
+    # Solution: Substitute tabs for spaces till is not considered a valid template by Cloudformation service.
+    # More details at: https://github.com/awslabs/aws-cfn-template-flip/issues/87
     if isinstance(file_content, bytes):
         file_content = file_content.decode("utf-8")
     file_content = replace_tabs(file_content)

--- a/cfripper/model/utils.py
+++ b/cfripper/model/utils.py
@@ -74,7 +74,24 @@ def extract_bucket_name_and_path_from_url(url):
     return bucket_name, path
 
 
+def replace_tabs(content: str, new_chars: str = "  ") -> str:
+    """
+    Substitute tabs of content variable for new_chars value
+    :param content: string to clean of tabs `\t`
+    :param new_chars: value to put in place of a tab. Default: two spaces
+    :return: the clean string
+    """
+    return content.replace("\t", new_chars)
+
+
 def convert_json_or_yaml_to_dict(file_content):
+    # BEGIN OF FIX
+    # Details at: https://github.com/awslabs/aws-cfn-template-flip/issues/87
+    if isinstance(file_content, bytes):
+        file_content = file_content.decode("utf-8")
+    file_content = replace_tabs(file_content)
+    # END OF FIX
+
     with suppress(ValueError):
         return json.loads(file_content)
 

--- a/tests/model/test_utils.py
+++ b/tests/model/test_utils.py
@@ -12,9 +12,11 @@ under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+from typing import Dict
+
 import pytest
 
-from cfripper.model.utils import extract_bucket_name_and_path_from_url
+from cfripper.model.utils import convert_json_or_yaml_to_dict, extract_bucket_name_and_path_from_url, replace_tabs
 
 
 @pytest.mark.parametrize(
@@ -41,3 +43,39 @@ from cfripper.model.utils import extract_bucket_name_and_path_from_url
 )
 def test_stack_delete(template_url, bucket, path):
     assert extract_bucket_name_and_path_from_url(template_url) == (bucket, path)
+
+
+@pytest.mark.parametrize(
+    "input, expected_output",
+    [
+        ("", ""),
+        (" ", " "),
+        ("\r\n", "\r\n"),
+        ("\t", "  "),
+        ("a\t", "a  "),
+        ("\ta", "  a"),
+        ("\ta\t", "  a  "),
+        ("a\ta", "a  a"),
+    ],
+)
+def test_replace_tabs(input, expected_output):
+    assert replace_tabs(input) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input, expected_output",
+    [
+        ('{"A": "a"}', {"A": "a"}),
+        ("A: a", {"A": "a"}),
+        ("\tA: a", {"A": "a"}),
+        ("\tA:\t  a\n  B: b", {"A": "a", "B": "b"}),
+    ],
+)
+def test_convert_json_or_yaml_to_dict(input, expected_output):
+    assert convert_json_or_yaml_to_dict(input) == expected_output
+
+
+def test_convert_json_or_yaml_to_dict_yaml_with_tabs():
+    cf_path = "tests/test_templates/others/yaml_with_tabs.yml"
+    with open(cf_path) as cf_script:
+        assert isinstance(convert_json_or_yaml_to_dict(cf_script.read()), Dict)

--- a/tests/test_templates/others/yaml_with_tabs.yml
+++ b/tests/test_templates/others/yaml_with_tabs.yml
@@ -1,0 +1,31 @@
+AWSTemplateFormatVersion: 2010-09-09
+Parameters:
+  TestParam:
+    Description: Test param
+    AllowedValues:
+      - a	
+      - b	
+    Default: a
+    Type: "String"
+Resources:
+  EC2Role:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: ''
+            Effect: Allow
+            Principal:
+              Service: ec2.amazonaws.com
+            Action: 'sts:AssumeRole'
+      Path: /
+      Policies:
+        - PolicyName: describe-policy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+            - Effect: Allow
+              Action:
+                - ec2:Describe*
+              Resource: "*"


### PR DESCRIPTION
**Problem:** 
AWS Cloudformation service accepts YML templates that contain tab characters. This is not compliant.
But CFRipper is going to accept those templates because are also accepted by Cloudformation service.

**Solution:** 
Substitute tabs for spaces till is not considered a valid template by Cloudformation service.

More details at: https://github.com/awslabs/aws-cfn-template-flip/issues/87