### PR TITLE
Improve kms handling and rule granularity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.12.0] - 2019-12-17
+### Added
+- `KMSKeyCrossAccountTrustRule`
+### Changed
+- `GenericWildcardPrincipalRule`, `PartialWildcardPrincipalRule`, `FullWildcardPrincipalRule` no longer check for
+wildcards in KMSKey principals.
+- Improved granularity of most rules 
+
 ## [0.11.3] - 2019-12-17
 ### Improvements
 - `S3CrossAccountTrustRule` now accepts resource level exceptions

--- a/cfripper/rules/__init__.py
+++ b/cfripper/rules/__init__.py
@@ -12,41 +12,80 @@ under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from cfripper.rules.cloudformation_authentication import *  # noqa: F403
-from cfripper.rules.cross_account_trust import *  # noqa: F403
-from cfripper.rules.ebs_volume_has_sse import *  # noqa: F403
-from cfripper.rules.hardcoded_RDS_password import *  # noqa: F403
-from cfripper.rules.iam_managed_policy_wildcard_action import *  # noqa: F403
-from cfripper.rules.iam_roles import *  # noqa: F403
-from cfripper.rules.kms_key_wildcard_principal import *  # noqa: F403
-from cfripper.rules.managed_policy_on_user import *  # noqa: F403
-from cfripper.rules.policy_on_user import *  # noqa: F403
-from cfripper.rules.privilege_escalation import *  # noqa: F403
-from cfripper.rules.s3_bucket_policy import *  # noqa: F403
-from cfripper.rules.s3_public_access import *  # noqa: F403
-from cfripper.rules.security_group import *  # noqa: F403
-from cfripper.rules.sns_topic_policy_not_principal import *  # noqa: F403
-from cfripper.rules.sqs_queue_policy import *  # noqa: F403
-from cfripper.rules.wildcard_principals import *  # noqa: F403
+from cfripper.rules.base_rules import PrincipalCheckingRule
+from cfripper.rules.cloudformation_authentication import CloudFormationAuthenticationRule
+from cfripper.rules.cross_account_trust import (
+    CrossAccountCheckingRule,
+    CrossAccountTrustRule,
+    KMSKeyCrossAccountTrustRule,
+    S3CrossAccountTrustRule,
+)
+from cfripper.rules.ebs_volume_has_sse import EBSVolumeHasSSERule
+from cfripper.rules.hardcoded_RDS_password import HardcodedRDSPasswordRule
+from cfripper.rules.iam_managed_policy_wildcard_action import IAMManagedPolicyWildcardActionRule
+from cfripper.rules.iam_roles import (
+    IAMRolesOverprivilegedRule,
+    IAMRoleWildcardActionOnPermissionsPolicyRule,
+    IAMRoleWildcardActionOnTrustPolicyRule,
+)
+from cfripper.rules.kms_key_wildcard_principal import KMSKeyWildcardPrincipal
+from cfripper.rules.managed_policy_on_user import ManagedPolicyOnUserRule
+from cfripper.rules.policy_on_user import PolicyOnUserRule
+from cfripper.rules.privilege_escalation import PrivilegeEscalationRule
+from cfripper.rules.s3_bucket_policy import S3BucketPolicyPrincipalRule, S3BucketPolicyWildcardActionRule
+from cfripper.rules.s3_public_access import S3BucketPublicReadAclAndListStatementRule, S3BucketPublicReadWriteAclRule
+from cfripper.rules.security_group import (
+    SecurityGroupIngressOpenToWorld,
+    SecurityGroupMissingEgressRule,
+    SecurityGroupOpenToWorldRule,
+)
+from cfripper.rules.sns_topic_policy_not_principal import SNSTopicPolicyNotPrincipalRule
+from cfripper.rules.sqs_queue_policy import (
+    SQSQueuePolicyNotPrincipalRule,
+    SQSQueuePolicyPublicRule,
+    SQSQueuePolicyWildcardActionRule,
+)
+from cfripper.rules.wildcard_principals import (
+    FullWildcardPrincipalRule,
+    GenericWildcardPrincipalRule,
+    PartialWildcardPrincipalRule,
+)
 
 DEFAULT_RULES = {
-    "IAMRolesOverprivilegedRule": IAMRolesOverprivilegedRule,  # noqa: F405
-    "SecurityGroupOpenToWorldRule": SecurityGroupOpenToWorldRule,  # noqa: F405
-    "S3BucketPublicReadWriteAclRule": S3BucketPublicReadWriteAclRule,  # noqa: F405
-    "SecurityGroupIngressOpenToWorld": SecurityGroupIngressOpenToWorld,  # noqa: F405
-    "ManagedPolicyOnUserRule": ManagedPolicyOnUserRule,  # noqa: F405
-    "PolicyOnUserRule": PolicyOnUserRule,  # noqa: F405
-    "SNSTopicPolicyNotPrincipalRule": SNSTopicPolicyNotPrincipalRule,  # noqa: F405
-    "SQSQueuePolicyNotPrincipalRule": SQSQueuePolicyNotPrincipalRule,  # noqa: F405
-    "S3BucketPolicyPrincipalRule": S3BucketPolicyPrincipalRule,  # noqa: F405
-    "EBSVolumeHasSSERule": EBSVolumeHasSSERule,  # noqa: F405
-    "PrivilegeEscalationRule": PrivilegeEscalationRule,  # noqa: F405
-    "CrossAccountTrustRule": CrossAccountTrustRule,  # noqa: F405
-    "S3BucketPublicReadAclAndListStatementRule": S3BucketPublicReadAclAndListStatementRule,  # noqa: F405
-    "SQSQueuePolicyPublicRule": SQSQueuePolicyPublicRule,  # noqa: F405
-    "S3CrossAccountTrustRule": S3CrossAccountTrustRule,  # noqa: F405
-    "HardcodedRDSPasswordRule": HardcodedRDSPasswordRule,  # noqa: F405
-    "KMSKeyWildcardPrincipal": KMSKeyWildcardPrincipal,  # noqa: F405
-    "FullWildcardPrincipal": FullWildcardPrincipalRule,  # noqa: F405
-    "PartialWildcardPrincipal": PartialWildcardPrincipalRule,  # noqa: F405
+    "CrossAccountTrustRule": CrossAccountTrustRule,
+    "EBSVolumeHasSSERule": EBSVolumeHasSSERule,
+    "FullWildcardPrincipal": FullWildcardPrincipalRule,
+    "HardcodedRDSPasswordRule": HardcodedRDSPasswordRule,
+    "IAMRolesOverprivilegedRule": IAMRolesOverprivilegedRule,
+    "KMSKeyCrossAccountTrustRule": KMSKeyCrossAccountTrustRule,
+    "KMSKeyWildcardPrincipal": KMSKeyWildcardPrincipal,
+    "ManagedPolicyOnUserRule": ManagedPolicyOnUserRule,
+    "PartialWildcardPrincipal": PartialWildcardPrincipalRule,
+    "PolicyOnUserRule": PolicyOnUserRule,
+    "PrivilegeEscalationRule": PrivilegeEscalationRule,
+    "S3BucketPolicyPrincipalRule": S3BucketPolicyPrincipalRule,
+    "S3BucketPublicReadAclAndListStatementRule": S3BucketPublicReadAclAndListStatementRule,
+    "S3BucketPublicReadWriteAclRule": S3BucketPublicReadWriteAclRule,
+    "S3CrossAccountTrustRule": S3CrossAccountTrustRule,
+    "SecurityGroupIngressOpenToWorld": SecurityGroupIngressOpenToWorld,
+    "SecurityGroupOpenToWorldRule": SecurityGroupOpenToWorldRule,
+    "SNSTopicPolicyNotPrincipalRule": SNSTopicPolicyNotPrincipalRule,
+    "SQSQueuePolicyNotPrincipalRule": SQSQueuePolicyNotPrincipalRule,
+    "SQSQueuePolicyPublicRule": SQSQueuePolicyPublicRule,
+}
+
+NON_DEFAULT_RULES = {
+    "CloudFormationAuthenticationRule": CloudFormationAuthenticationRule,
+    "GenericWildcardPrincipalRule": GenericWildcardPrincipalRule,
+    "IAMManagedPolicyWildcardActionRule": IAMManagedPolicyWildcardActionRule,
+    "IAMRoleWildcardActionOnPermissionsPolicyRule": IAMRoleWildcardActionOnPermissionsPolicyRule,
+    "IAMRoleWildcardActionOnTrustPolicyRule": IAMRoleWildcardActionOnTrustPolicyRule,
+    "S3BucketPolicyWildcardActionRule": S3BucketPolicyWildcardActionRule,
+    "SecurityGroupMissingEgressRule": SecurityGroupMissingEgressRule,
+    "SQSQueuePolicyWildcardActionRule": SQSQueuePolicyWildcardActionRule,
+}
+
+BASE_CLASSES = {
+    "CrossAccountCheckingRule": CrossAccountCheckingRule,
+    "PrincipalCheckingRule": PrincipalCheckingRule,
 }

--- a/cfripper/rules/base_rules.py
+++ b/cfripper/rules/base_rules.py
@@ -21,6 +21,8 @@ logger = logging.getLogger(__file__)
 
 
 class PrincipalCheckingRule(Rule):
+    """Abstract class for rules that check principals"""
+
     _valid_principals = None
 
     def _get_whitelist_from_config(self, services: List[str] = None) -> Set[str]:

--- a/cfripper/rules/cloudformation_authentication.py
+++ b/cfripper/rules/cloudformation_authentication.py
@@ -13,6 +13,8 @@ CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
 __all__ = ["CloudFormationAuthenticationRule"]
+
+from cfripper.model.enums import RuleGranularity
 from cfripper.model.rule import Rule
 
 
@@ -20,8 +22,9 @@ class CloudFormationAuthenticationRule(Rule):
     """This rule checks for hardcoded credentials"""
 
     REASON = "Hardcoded credentials in {}"
+    GRANULARITY = RuleGranularity.RESOURCE
 
     def invoke(self, cfmodel):
         for logical_id, resource in cfmodel.Resources.items():
             if resource.has_hardcoded_credentials():
-                self.add_failure(type(self).__name__, self.REASON.format(logical_id))
+                self.add_failure(type(self).__name__, self.REASON.format(logical_id), resource_ids={logical_id})

--- a/cfripper/rules/ebs_volume_has_sse.py
+++ b/cfripper/rules/ebs_volume_has_sse.py
@@ -13,7 +13,7 @@ CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
 __all__ = ["EBSVolumeHasSSERule"]
-from cfripper.model.enums import RuleMode
+from cfripper.model.enums import RuleGranularity, RuleMode
 from cfripper.model.rule import Rule
 
 
@@ -24,9 +24,10 @@ class EBSVolumeHasSSERule(Rule):
 
     REASON = "EBS volume {} should have server-side encryption enabled"
     RULE_MODE = RuleMode.MONITOR
+    GRANULARITY = RuleGranularity.RESOURCE
 
     def invoke(self, cfmodel):
         for logical_id, resource in cfmodel.Resources.items():
             if resource.Type == "AWS::EC2::Volume":
                 if resource.Properties.get("Encrypted") != "true":
-                    self.add_failure(type(self).__name__, self.REASON.format(logical_id))
+                    self.add_failure(type(self).__name__, self.REASON.format(logical_id), resource_ids={logical_id})

--- a/cfripper/rules/hardcoded_RDS_password.py
+++ b/cfripper/rules/hardcoded_RDS_password.py
@@ -15,6 +15,7 @@ specific language governing permissions and limitations under the License.
 __all__ = ["HardcodedRDSPasswordRule"]
 from pycfmodel.model.parameter import Parameter
 
+from cfripper.model.enums import RuleGranularity
 from cfripper.model.rule import Rule
 
 
@@ -25,6 +26,7 @@ class HardcodedRDSPasswordRule(Rule):
 
     REASON_DEFAULT = "Default RDS {} password parameter (readable in plain-text) for {}."
     REASON_MISSING_NOECHO = "RDS {} password parameter missing NoEcho for {}."
+    GRANULARITY = RuleGranularity.RESOURCE
 
     def invoke(self, cfmodel):
         password_protected_cluster_ids = []
@@ -55,10 +57,16 @@ class HardcodedRDSPasswordRule(Rule):
         master_user_password = resource.Properties.get("MasterUserPassword", Parameter.NO_ECHO_NO_DEFAULT)
         resource_type = resource.Type.replace("AWS::RDS::DB", "")
         if master_user_password == Parameter.NO_ECHO_WITH_DEFAULT:
-            self.add_failure(type(self).__name__, self.REASON_DEFAULT.format(resource_type, logical_id))
+            self.add_failure(
+                type(self).__name__, self.REASON_DEFAULT.format(resource_type, logical_id), resource_ids={logical_id}
+            )
             return True
         elif master_user_password not in (Parameter.NO_ECHO_NO_DEFAULT, Parameter.NO_ECHO_WITH_VALUE):
-            self.add_failure(type(self).__name__, self.REASON_MISSING_NOECHO.format(resource_type, logical_id))
+            self.add_failure(
+                type(self).__name__,
+                self.REASON_MISSING_NOECHO.format(resource_type, logical_id),
+                resource_ids={logical_id},
+            )
             return True
 
         return False

--- a/cfripper/rules/iam_managed_policy_wildcard_action.py
+++ b/cfripper/rules/iam_managed_policy_wildcard_action.py
@@ -16,6 +16,7 @@ __all__ = ["IAMManagedPolicyWildcardActionRule"]
 from pycfmodel.model.resources.iam_managed_policy import IAMManagedPolicy
 
 from cfripper.config.regex import REGEX_WILDCARD_POLICY_ACTION
+from cfripper.model.enums import RuleGranularity
 from cfripper.model.rule import Rule
 
 
@@ -24,6 +25,7 @@ class IAMManagedPolicyWildcardActionRule(Rule):
     This rule checks for wildcards in IAM Managed policies
     """
 
+    GRANULARITY = RuleGranularity.RESOURCE
     REASON = "IAM managed policy {} should not allow * action"
 
     def invoke(self, cfmodel):
@@ -31,4 +33,4 @@ class IAMManagedPolicyWildcardActionRule(Rule):
             if isinstance(resource, IAMManagedPolicy) and resource.Properties.PolicyDocument.allowed_actions_with(
                 REGEX_WILDCARD_POLICY_ACTION
             ):
-                self.add_failure(type(self).__name__, self.REASON.format(logical_id))
+                self.add_failure(type(self).__name__, self.REASON.format(logical_id), resource_ids={logical_id})

--- a/cfripper/rules/kms_key_wildcard_principal.py
+++ b/cfripper/rules/kms_key_wildcard_principal.py
@@ -19,6 +19,7 @@ import re
 from pycfmodel.model.cf_model import CFModel
 from pycfmodel.model.resources.kms_key import KMSKey
 
+from cfripper.model.enums import RuleGranularity
 from cfripper.model.rule import Rule
 
 logger = logging.getLogger(__file__)
@@ -28,6 +29,8 @@ class KMSKeyWildcardPrincipal(Rule):
     """
     This rule checks for KMS keys that contain wildcards in the key policies
     """
+
+    GRANULARITY = RuleGranularity.RESOURCE
 
     REASON = "KMS Key policy {} should not allow wildcard principals"
     CONTAINS_WILDCARD_PATTERN = re.compile(r"^(\w*:)?\*$")
@@ -45,4 +48,6 @@ class KMSKeyWildcardPrincipal(Rule):
                                         f"because there are conditions: {statement.Condition}"
                                     )
                                 else:
-                                    self.add_failure(type(self).__name__, self.REASON.format(logical_id))
+                                    self.add_failure(
+                                        type(self).__name__, self.REASON.format(logical_id), resource_ids={logical_id}
+                                    )

--- a/cfripper/rules/managed_policy_on_user.py
+++ b/cfripper/rules/managed_policy_on_user.py
@@ -16,7 +16,7 @@ __all__ = ["ManagedPolicyOnUserRule"]
 from pycfmodel.model.cf_model import CFModel
 from pycfmodel.model.resources.iam_managed_policy import IAMManagedPolicy
 
-from cfripper.model.enums import RuleMode
+from cfripper.model.enums import RuleGranularity, RuleMode
 from cfripper.model.rule import Rule
 
 
@@ -27,8 +27,9 @@ class ManagedPolicyOnUserRule(Rule):
 
     REASON = "IAM managed policy {} should not apply directly to users. Should be on group"
     RULE_MODE = RuleMode.MONITOR
+    GRANULARITY = RuleGranularity.RESOURCE
 
     def invoke(self, cfmodel: CFModel):
         for logical_id, resource in cfmodel.Resources.items():
             if isinstance(resource, IAMManagedPolicy) and resource.Properties.Users:
-                self.add_failure(type(self).__name__, self.REASON.format(logical_id))
+                self.add_failure(type(self).__name__, self.REASON.format(logical_id), resource_ids={logical_id})

--- a/cfripper/rules/policy_on_user.py
+++ b/cfripper/rules/policy_on_user.py
@@ -16,7 +16,7 @@ __all__ = ["PolicyOnUserRule"]
 from pycfmodel.model.cf_model import CFModel
 from pycfmodel.model.resources.iam_policy import IAMPolicy
 
-from cfripper.model.enums import RuleMode
+from cfripper.model.enums import RuleGranularity, RuleMode
 from cfripper.model.rule import Rule
 
 
@@ -25,10 +25,11 @@ class PolicyOnUserRule(Rule):
     Rule that checks for IAM policies attached directly to users
     """
 
+    GRANULARITY = RuleGranularity.RESOURCE
     REASON = "IAM policy {} should not apply directly to users. Should be on group"
     RULE_MODE = RuleMode.MONITOR
 
     def invoke(self, cfmodel: CFModel):
         for logical_id, resource in cfmodel.Resources.items():
             if isinstance(resource, IAMPolicy) and resource.Properties.Users:
-                self.add_failure(type(self).__name__, self.REASON.format(logical_id))
+                self.add_failure(type(self).__name__, self.REASON.format(logical_id), resource_ids={logical_id})

--- a/cfripper/rules/privilege_escalation.py
+++ b/cfripper/rules/privilege_escalation.py
@@ -15,6 +15,7 @@ specific language governing permissions and limitations under the License.
 __all__ = ["PrivilegeEscalationRule"]
 from pycfmodel.model.resources.iam_policy import IAMPolicy
 
+from cfripper.model.enums import RuleGranularity
 from cfripper.model.rule import Rule
 
 
@@ -23,6 +24,7 @@ class PrivilegeEscalationRule(Rule):
     Rule that checks for actions that allow privilege escalation in IAM policies
     """
 
+    GRANULARITY = RuleGranularity.RESOURCE
     REASON = "{} has blacklisted IAM action {}"
     IAM_BLACKLIST = set(
         action.lower()
@@ -49,4 +51,6 @@ class PrivilegeEscalationRule(Rule):
             if isinstance(resource, IAMPolicy):
                 policy_actions = set(action.lower() for action in resource.Properties.PolicyDocument.get_iam_actions())
                 for violation in policy_actions.intersection(self.IAM_BLACKLIST):
-                    self.add_failure(type(self).__name__, self.REASON.format(logical_id, violation))
+                    self.add_failure(
+                        type(self).__name__, self.REASON.format(logical_id, violation), resource_ids={logical_id}
+                    )

--- a/cfripper/rules/s3_public_access.py
+++ b/cfripper/rules/s3_public_access.py
@@ -19,7 +19,7 @@ import re
 
 from pycfmodel.model.resources.s3_bucket_policy import S3BucketPolicy
 
-from cfripper.model.enums import RuleMode, RuleRisk
+from cfripper.model.enums import RuleGranularity, RuleMode, RuleRisk
 from cfripper.model.rule import Rule
 
 logger = logging.getLogger(__file__)
@@ -30,6 +30,7 @@ class S3BucketPublicReadAclAndListStatementRule(Rule):
     Rule that checks for public read access to S3 bucket policies
     """
 
+    GRANULARITY = RuleGranularity.RESOURCE
     REASON = "S3 Bucket {} should not have a public read acl and list bucket statement"
     RULE_MODE = RuleMode.DEBUG
 
@@ -43,7 +44,7 @@ class S3BucketPublicReadAclAndListStatementRule(Rule):
                     bucket_name = bucket_name[len("UNDEFINED_PARAM_") :]
                 bucket = cfmodel.Resources.get(bucket_name)
                 if bucket and bucket.Properties.get("AccessControl") == "PublicRead":
-                    self.add_failure(type(self).__name__, self.REASON.format(logical_id))
+                    self.add_failure(type(self).__name__, self.REASON.format(logical_id), resource_ids={logical_id})
 
 
 class S3BucketPublicReadWriteAclRule(Rule):
@@ -51,6 +52,7 @@ class S3BucketPublicReadWriteAclRule(Rule):
     Rule that checks for public read access to S3 buckets
     """
 
+    GRANULARITY = RuleGranularity.RESOURCE
     REASON = "S3 Bucket {} should not have a public read-write acl"
     RISK_VALUE = RuleRisk.HIGH
 
@@ -61,4 +63,4 @@ class S3BucketPublicReadWriteAclRule(Rule):
                 and hasattr(resource, "Properties")
                 and resource.Properties.get("AccessControl") == "PublicReadWrite"
             ):
-                self.add_failure(type(self).__name__, self.REASON.format(logical_id))
+                self.add_failure(type(self).__name__, self.REASON.format(logical_id), resource_ids={logical_id})

--- a/cfripper/rules/sns_topic_policy_not_principal.py
+++ b/cfripper/rules/sns_topic_policy_not_principal.py
@@ -16,7 +16,7 @@ __all__ = ["SNSTopicPolicyNotPrincipalRule"]
 
 from pycfmodel.model.resources.sns_topic_policy import SNSTopicPolicy
 
-from cfripper.model.enums import RuleMode
+from cfripper.model.enums import RuleGranularity, RuleMode
 from cfripper.model.rule import Rule
 
 
@@ -25,6 +25,7 @@ class SNSTopicPolicyNotPrincipalRule(Rule):
     Rule that checks for `Allow` and `NotPrincipal` at the same time in SNS Topic PolicyDocuments
     """
 
+    GRANULARITY = RuleGranularity.RESOURCE
     REASON = "SNS Topic {} policy should not allow Allow and NotPrincipal at the same time"
     RULE_MODE = RuleMode.MONITOR
 
@@ -33,4 +34,4 @@ class SNSTopicPolicyNotPrincipalRule(Rule):
             if isinstance(resource, SNSTopicPolicy):
                 for statement in resource.Properties.PolicyDocument._statement_as_list():
                     if statement.NotPrincipal:
-                        self.add_failure(type(self).__name__, self.REASON.format(logical_id))
+                        self.add_failure(type(self).__name__, self.REASON.format(logical_id), resource_ids={logical_id})

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ docs_requires = [
 
 setup(
     name="cfripper",
-    version="0.11.3",
+    version="0.12.0",
     author="Skyscanner Product Security",
     author_email="security@skyscanner.net",
     long_description=long_description,

--- a/tests/rules/test_GenericWildcardPrincipal.py
+++ b/tests/rules/test_GenericWildcardPrincipal.py
@@ -89,3 +89,13 @@ def test_wildcard_principal_rule_is_whitelisted_retrieved_correctly(mock_rule_to
     wildcard_principal_rule = GenericWildcardPrincipalRule(config=config, result=None)
 
     assert wildcard_principal_rule.resource_is_whitelisted(logical_id="resource_1") is True
+
+
+def test_generic_wildcard_ignores_kms():
+    result = Result()
+    rule = GenericWildcardPrincipalRule(Config(aws_account_id="123456789", aws_principals=["999999999"]), result)
+    model = get_cfmodel_from("rules/CrossAccountTrustRule/kms_basic.yml").resolve(
+        extra_params={"Principal": "arn:aws:iam::*:*"}
+    )
+    rule.invoke(model)
+    assert result.valid

--- a/tests/test_templates/rules/CrossAccountTrustRule/kms_basic.yml
+++ b/tests/test_templates/rules/CrossAccountTrustRule/kms_basic.yml
@@ -1,0 +1,37 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Testing KMS
+
+Parameters:
+  Principal:
+    Type: String
+
+Resources:
+  KMSKey:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: Test key to test KMS best practices
+      Enabled: true
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: 2012-10-17
+        Id: "test_key_policy"
+        Statement:
+          - Sid: "Allow administration of the key"
+            Effect: Allow
+            Principal:
+              AWS:
+                - !Ref Principal
+            Action:
+              - "kms:Create*"
+              - "kms:Describe*"
+              - "kms:Enable*"
+              - "kms:List*"
+              - "kms:Put*"
+              - "kms:Update*"
+              - "kms:Revoke*"
+              - "kms:Disable*"
+              - "kms:Get*"
+              - "kms:Delete*"
+              - "kms:ScheduleKeyDeletion"
+              - "kms:CancelKeyDeletion"
+            Resource: "*"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -20,6 +20,8 @@ from typing import Dict, List
 from pycfmodel import parse
 from pycfmodel.model.cf_model import CFModel
 
+from cfripper.model.utils import convert_json_or_yaml_to_dict
+
 FIXTURE_ROOT_PATH = Path(__file__).parent / "test_templates"
 
 
@@ -40,4 +42,6 @@ def get_fixture_json(path: str) -> Dict:
 
 
 def get_cfmodel_from(path: str) -> CFModel:
-    return parse(get_fixture_json(path))
+    with Path(FIXTURE_ROOT_PATH / path).open() as f:
+        content = f.read()
+    return parse(convert_json_or_yaml_to_dict(content))


### PR DESCRIPTION
### Added
- `KMSKeyCrossAccountTrustRule`
### Changed
- `GenericWildcardPrincipalRule`, `PartialWildcardPrincipalRule`, `FullWildcardPrincipalRule` no longer check for
wildcards in KMSKey principals.
- Improved granularity of most rules 

Besides this, I've refactored the rule `__init__` file and this has surfaced a few non-default rules. We need to discuss what to do with those.