### PR TITLE
Accepts sts for principals in `CrossAccountCheckingRule` rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.12.1] - 2020-01-09
+### Fixes
+- Fix for `CrossAccountCheckingRule` was adding errors when the principal was sts when it shouldn't. 
+### Added
+- `get_account_id_from_sts_arn` and `get_aws_service_from_arn` in utils.
+
 ## [0.12.0] - 2020-01-08
 ### Added
 - Adds CLI to package

--- a/cfripper/__version__.py
+++ b/cfripper/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (0, 12, 0)
+VERSION = (0, 12, 1)
 
 __version__ = ".".join(map(str, VERSION))

--- a/cfripper/config/regex.py
+++ b/cfripper/config/regex.py
@@ -94,7 +94,7 @@ REGEX_ARN = re.compile(r"^arn:aws:(\w+):(\w*):(\d*):(.+)$")
 
 """
 Check for iam arns
-It has 2 groups. The first one for account id, the last one  for resource id
+It has 2 groups. The first one for account id, the last one for resource id
 Valid:
 - arn:aws:iam::437628376:not-root
 Invalid:
@@ -106,7 +106,7 @@ REGEX_IAM_ARN = re.compile(r"^arn:aws:iam::(\d*):(.*)$")
 
 """
 Check for sts arns
-It has 2 groups. The first one for account id, the last one  for resource id
+It has 2 groups. The first one for account id, the last one for resource id
 Valid:
 - arn:aws:sts::437628376:not-root
 Invalid:

--- a/cfripper/config/regex.py
+++ b/cfripper/config/regex.py
@@ -80,19 +80,6 @@ REGEX_IS_STAR = re.compile(r"^\*$")
 
 
 """
-Check for aws service
-It has 2 group. The first one for service name, the second one for the rest
-Valid:
-- arn:aws:sts::437628376:not-root
-- arn:aws:iam::437628376:root
-- arn:aws:s3:::my_corporate_bucket
-Invalid:
-- potato
-"""
-REGEX_AWS_SERVICE_ARN = re.compile(r"^arn:aws:(\w+):(.+)$")
-
-
-"""
 Check for arns
 It has 4 groups. The first one for service name, the second one for region, the third, for account id, the last one
 for resource id

--- a/cfripper/config/regex.py
+++ b/cfripper/config/regex.py
@@ -78,6 +78,20 @@ Invalid:
 """
 REGEX_IS_STAR = re.compile(r"^\*$")
 
+
+"""
+Check for aws service
+It has 2 group. The first one for service name, the second one for the rest
+Valid:
+- arn:aws:sts::437628376:not-root
+- arn:aws:iam::437628376:root
+- arn:aws:s3:::my_corporate_bucket
+Invalid:
+- potato
+"""
+REGEX_AWS_SERVICE_ARN = re.compile(r"^arn:aws:(\w+):(.+)$")
+
+
 """
 Check for arns
 It has 4 groups. The first one for service name, the second one for region, the third, for account id, the last one
@@ -101,6 +115,18 @@ Invalid:
 - potato
 """
 REGEX_IAM_ARN = re.compile(r"^arn:aws:iam::(\d*):(.*)$")
+
+
+"""
+Check for sts arns
+It has 2 groups. The first one for account id, the last one  for resource id
+Valid:
+- arn:aws:sts::437628376:not-root
+Invalid:
+- arn:aws:s3:::my_corporate_bucket
+- potato
+"""
+REGEX_STS_ARN = re.compile(r"^arn:aws:sts::(\d*):(.*)$")
 
 
 """

--- a/cfripper/model/utils.py
+++ b/cfripper/model/utils.py
@@ -135,7 +135,9 @@ def get_account_id_from_principal(principal: str) -> Optional[str]:
         return principal
 
     aws_service = get_aws_service_from_arn(principal)
-    if aws 
+    if aws_service not in ["iam", "sts"]:
+        return None
+    
     if aws_service == "iam":
         return get_account_id_from_iam_arn(principal)
     elif aws_service == "sts":

--- a/cfripper/model/utils.py
+++ b/cfripper/model/utils.py
@@ -25,7 +25,7 @@ import yaml
 from cfn_flip import to_json
 from pycfmodel.model.resources.properties.policy import Policy
 
-from cfripper.config.regex import REGEX_ARN, REGEX_AWS_SERVICE_ARN, REGEX_IAM_ARN, REGEX_STS_ARN
+from cfripper.config.regex import REGEX_ARN, REGEX_IAM_ARN, REGEX_STS_ARN
 
 logger = logging.getLogger(__file__)
 
@@ -107,9 +107,9 @@ def get_managed_policy(managed_policy_arn):
 
 
 def get_aws_service_from_arn(arn: str) -> Optional[str]:
-    match = REGEX_AWS_SERVICE_ARN.match(arn)
+    match = REGEX_ARN.match(arn)
     if match:
-        return match.group(1)
+        return match.group(2)
 
 
 def get_account_id_from_arn(arn: str) -> Optional[str]:
@@ -135,6 +135,7 @@ def get_account_id_from_principal(principal: str) -> Optional[str]:
         return principal
 
     aws_service = get_aws_service_from_arn(principal)
+    if aws 
     if aws_service == "iam":
         return get_account_id_from_iam_arn(principal)
     elif aws_service == "sts":

--- a/cfripper/model/utils.py
+++ b/cfripper/model/utils.py
@@ -109,7 +109,7 @@ def get_managed_policy(managed_policy_arn):
 def get_aws_service_from_arn(arn: str) -> Optional[str]:
     match = REGEX_ARN.match(arn)
     if match:
-        return match.group(2)
+        return match.group(1)
 
 
 def get_account_id_from_arn(arn: str) -> Optional[str]:

--- a/cfripper/model/utils.py
+++ b/cfripper/model/utils.py
@@ -137,7 +137,7 @@ def get_account_id_from_principal(principal: str) -> Optional[str]:
     aws_service = get_aws_service_from_arn(principal)
     if aws_service not in ["iam", "sts"]:
         return None
-    
+
     if aws_service == "iam":
         return get_account_id_from_iam_arn(principal)
     elif aws_service == "sts":

--- a/tests/config/test_regex.py
+++ b/tests/config/test_regex.py
@@ -16,7 +16,6 @@ import pytest
 
 from cfripper.config.regex import (
     REGEX_ARN,
-    REGEX_AWS_SERVICE_ARN,
     REGEX_CONTAINS_STAR,
     REGEX_CROSS_ACCOUNT_ROOT,
     REGEX_FULL_WILDCARD_PRINCIPAL,
@@ -58,10 +57,6 @@ from cfripper.config.regex import (
         (REGEX_IS_STAR, "*abcdef", False),
         (REGEX_IS_STAR, "arn:aws:iam::437628376:not-root", False),
         (REGEX_IS_STAR, "potato", False),
-        (REGEX_AWS_SERVICE_ARN, "arn:aws:sts::437628376:root", True),
-        (REGEX_AWS_SERVICE_ARN, "arn:aws:iam::437628376:root", True),
-        (REGEX_AWS_SERVICE_ARN, "arn:aws:s3:::my_corporate_bucket", True),
-        (REGEX_AWS_SERVICE_ARN, "potato", False),
         (REGEX_ARN, "arn:aws:iam::437628376:not-root", True),
         (REGEX_ARN, "arn:aws:iam::437628376:root", True),
         (REGEX_ARN, "arn:aws:s3:::my_corporate_bucket", True),

--- a/tests/config/test_regex.py
+++ b/tests/config/test_regex.py
@@ -16,12 +16,14 @@ import pytest
 
 from cfripper.config.regex import (
     REGEX_ARN,
+    REGEX_AWS_SERVICE_ARN,
     REGEX_CONTAINS_STAR,
     REGEX_CROSS_ACCOUNT_ROOT,
     REGEX_FULL_WILDCARD_PRINCIPAL,
     REGEX_HAS_STAR_OR_STAR_AFTER_COLON,
     REGEX_IAM_ARN,
     REGEX_IS_STAR,
+    REGEX_STS_ARN,
     REGEX_WILDCARD_POLICY_ACTION,
 )
 
@@ -56,6 +58,10 @@ from cfripper.config.regex import (
         (REGEX_IS_STAR, "*abcdef", False),
         (REGEX_IS_STAR, "arn:aws:iam::437628376:not-root", False),
         (REGEX_IS_STAR, "potato", False),
+        (REGEX_AWS_SERVICE_ARN, "arn:aws:sts::437628376:root", True),
+        (REGEX_AWS_SERVICE_ARN, "arn:aws:iam::437628376:root", True),
+        (REGEX_AWS_SERVICE_ARN, "arn:aws:s3:::my_corporate_bucket", True),
+        (REGEX_AWS_SERVICE_ARN, "potato", False),
         (REGEX_ARN, "arn:aws:iam::437628376:not-root", True),
         (REGEX_ARN, "arn:aws:iam::437628376:root", True),
         (REGEX_ARN, "arn:aws:s3:::my_corporate_bucket", True),
@@ -64,6 +70,10 @@ from cfripper.config.regex import (
         (REGEX_IAM_ARN, "arn:aws:iam::437628376:root", True),
         (REGEX_IAM_ARN, "arn:aws:s3:::my_corporate_bucket", False),
         (REGEX_IAM_ARN, "potato", False),
+        (REGEX_STS_ARN, "arn:aws:sts::437628376:not-root", True),
+        (REGEX_STS_ARN, "arn:aws:sts::437628376:root", True),
+        (REGEX_STS_ARN, "arn:aws:s3:::my_corporate_bucket", False),
+        (REGEX_STS_ARN, "potato", False),
         (REGEX_HAS_STAR_OR_STAR_AFTER_COLON, "arn:aws:iam::437628376:*", True),
         (REGEX_HAS_STAR_OR_STAR_AFTER_COLON, "*", True),
         (REGEX_HAS_STAR_OR_STAR_AFTER_COLON, "arn:aws:iam::437628376:root", False),

--- a/tests/rules/test_CrossAccountTrustRule.py
+++ b/tests/rules/test_CrossAccountTrustRule.py
@@ -214,6 +214,17 @@ def test_kms_cross_account_failure(principal):
     )
 
 
+@pytest.mark.parametrize(
+    "principal", ["arn:aws:iam::123456789:root", "arn:aws:iam::123456789:not-root", "arn:aws:iam::123456789:not-root*"],
+)
+def test_kms_cross_account_success(principal):
+    result = Result()
+    rule = KMSKeyCrossAccountTrustRule(Config(aws_account_id="123456789", aws_principals=["999999999"]), result)
+    model = get_cfmodel_from("rules/CrossAccountTrustRule/kms_basic.yml").resolve(extra_params={"Principal": principal})
+    rule.invoke(model)
+    assert result.valid
+
+
 def test_sts_valid(template_valid_with_sts):
     result = Result()
     rule = KMSKeyCrossAccountTrustRule(Config(aws_account_id="123456789", aws_principals=["999999999"]), result)

--- a/tests/test_templates/rules/CrossAccountTrustRule/invalid_with_sts.yml
+++ b/tests/test_templates/rules/CrossAccountTrustRule/invalid_with_sts.yml
@@ -1,0 +1,23 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  KmsMasterKey:
+    Type: "AWS::KMS::Key"
+    Properties:
+      Description: "kms-master-key-test"
+      KeyPolicy:
+        Version: "2012-10-17"
+        Id: "kms-key"
+        Statement:
+          - Sid: "Allow use of the key"
+            Effect: "Allow"
+            Principal:
+              AWS:
+                - "arn:aws:iam::123456789:role/test-role"
+                - "arn:aws:sts::999999999:assumed-role/test-role/session"
+            Action:
+              - "kms:Encrypt"
+              - "kms:Decrypt"
+              - "kms:ReEncrypt*"
+              - "kms:GenerateDataKey*"
+              - "kms:DescribeKey"
+            Resource: "*"

--- a/tests/test_templates/rules/CrossAccountTrustRule/valid_with_sts.yml
+++ b/tests/test_templates/rules/CrossAccountTrustRule/valid_with_sts.yml
@@ -1,0 +1,23 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  KmsMasterKey:
+    Type: "AWS::KMS::Key"
+    Properties:
+      Description: "kms-master-key-test"
+      KeyPolicy:
+        Version: "2012-10-17"
+        Id: "kms-key"
+        Statement:
+          - Sid: "Allow use of the key"
+            Effect: "Allow"
+            Principal:
+              AWS:
+                - "arn:aws:iam::123456789:role/test-role"
+                - "arn:aws:sts::123456789:assumed-role/test-role/session"
+            Action:
+              - "kms:Encrypt"
+              - "kms:Decrypt"
+              - "kms:ReEncrypt*"
+              - "kms:GenerateDataKey*"
+              - "kms:DescribeKey"
+            Resource: "*"


### PR DESCRIPTION
### Fixes
- Fix for `CrossAccountCheckingRule` was adding errors when the principal was sts when it shouldn't. 
### Added
- `get_account_id_from_sts_arn` and `get_aws_service_from_arn` in utils.