### PR TITLE
Update license

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ If you are adding a new file it should have a header like this:
 
 ```
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/cfripper/__init__.py
+++ b/cfripper/__init__.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/cfripper/boto3_client.py
+++ b/cfripper/boto3_client.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/cfripper/config/__init__.py
+++ b/cfripper/config/__init__.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/cfripper/config/config.py
+++ b/cfripper/config/config.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/cfripper/config/logger.py
+++ b/cfripper/config/logger.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/cfripper/config/regex.py
+++ b/cfripper/config/regex.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/cfripper/config/whitelist.py
+++ b/cfripper/config/whitelist.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/cfripper/main.py
+++ b/cfripper/main.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/cfripper/model/__init__.py
+++ b/cfripper/model/__init__.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/cfripper/model/enums.py
+++ b/cfripper/model/enums.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/cfripper/model/result.py
+++ b/cfripper/model/result.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/cfripper/model/rule.py
+++ b/cfripper/model/rule.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/cfripper/model/utils.py
+++ b/cfripper/model/utils.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/cfripper/rule_processor.py
+++ b/cfripper/rule_processor.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/cfripper/rules/__init__.py
+++ b/cfripper/rules/__init__.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/cfripper/rules/base_rules.py
+++ b/cfripper/rules/base_rules.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/cfripper/rules/cloudformation_authentication.py
+++ b/cfripper/rules/cloudformation_authentication.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/cfripper/rules/cross_account_trust.py
+++ b/cfripper/rules/cross_account_trust.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/cfripper/rules/ebs_volume_has_sse.py
+++ b/cfripper/rules/ebs_volume_has_sse.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/cfripper/rules/hardcoded_RDS_password.py
+++ b/cfripper/rules/hardcoded_RDS_password.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/cfripper/rules/iam_roles.py
+++ b/cfripper/rules/iam_roles.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/cfripper/rules/kms_key_wildcard_principal.py
+++ b/cfripper/rules/kms_key_wildcard_principal.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/cfripper/rules/managed_policy_on_user.py
+++ b/cfripper/rules/managed_policy_on_user.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/cfripper/rules/policy_on_user.py
+++ b/cfripper/rules/policy_on_user.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/cfripper/rules/privilege_escalation.py
+++ b/cfripper/rules/privilege_escalation.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/cfripper/rules/s3_bucket_policy.py
+++ b/cfripper/rules/s3_bucket_policy.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/cfripper/rules/s3_public_access.py
+++ b/cfripper/rules/s3_public_access.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/cfripper/rules/security_group.py
+++ b/cfripper/rules/security_group.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/cfripper/rules/sns_topic_policy_not_principal.py
+++ b/cfripper/rules/sns_topic_policy_not_principal.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/cfripper/rules/sqs_queue_policy.py
+++ b/cfripper/rules/sqs_queue_policy.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/cfripper/rules/wildcard_policies.py
+++ b/cfripper/rules/wildcard_policies.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/cfripper/rules/wildcard_principals.py
+++ b/cfripper/rules/wildcard_principals.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/simulator/simulator.py
+++ b/simulator/simulator.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/config/test_regex.py
+++ b/tests/config/test_regex.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/model/test_principal_checking_rule.py
+++ b/tests/model/test_principal_checking_rule.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/model/test_result.py
+++ b/tests/model/test_result.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/model/test_rule_processor.py
+++ b/tests/model/test_rule_processor.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/model/test_utils.py
+++ b/tests/model/test_utils.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/rules/test_CloudFormationAuthenticationRule.py
+++ b/tests/rules/test_CloudFormationAuthenticationRule.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/rules/test_CrossAccountTrustRule.py
+++ b/tests/rules/test_CrossAccountTrustRule.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/rules/test_EBSVolumeHasSSERule.py
+++ b/tests/rules/test_EBSVolumeHasSSERule.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/rules/test_FullWildcardPrincipal.py
+++ b/tests/rules/test_FullWildcardPrincipal.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/rules/test_GenericWildcardPrincipal.py
+++ b/tests/rules/test_GenericWildcardPrincipal.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/rules/test_HardcodedRDSPasswordRule.py
+++ b/tests/rules/test_HardcodedRDSPasswordRule.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/rules/test_IAMRoleWildcardActionOnPolicyRule.py
+++ b/tests/rules/test_IAMRoleWildcardActionOnPolicyRule.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/rules/test_IAMRolesOverprivilegedRule.py
+++ b/tests/rules/test_IAMRolesOverprivilegedRule.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/rules/test_KMSKeyWildcardPrincipal.py
+++ b/tests/rules/test_KMSKeyWildcardPrincipal.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/rules/test_ManagedPolicyOnUserRule.py
+++ b/tests/rules/test_ManagedPolicyOnUserRule.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/rules/test_PartialWildcardPrincipal.py
+++ b/tests/rules/test_PartialWildcardPrincipal.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/rules/test_PolicyOnUserRule.py
+++ b/tests/rules/test_PolicyOnUserRule.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/rules/test_PrivilegeEscalationRule.py
+++ b/tests/rules/test_PrivilegeEscalationRule.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/rules/test_S3BucketPolicyPrincipalRule.py
+++ b/tests/rules/test_S3BucketPolicyPrincipalRule.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/rules/test_S3BucketPublicReadAclAndListStatementRule.py
+++ b/tests/rules/test_S3BucketPublicReadAclAndListStatementRule.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/rules/test_S3BucketPublicReadWriteAclRule.py
+++ b/tests/rules/test_S3BucketPublicReadWriteAclRule.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/rules/test_S3CrossAccountTrustRule.py
+++ b/tests/rules/test_S3CrossAccountTrustRule.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/rules/test_SNSTopicPolicyNotPrincipalRule.py
+++ b/tests/rules/test_SNSTopicPolicyNotPrincipalRule.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/rules/test_SQSQueuePolicyNotPrincipalRule.py
+++ b/tests/rules/test_SQSQueuePolicyNotPrincipalRule.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/rules/test_SQSQueuePolicyPublicRule.py
+++ b/tests/rules/test_SQSQueuePolicyPublicRule.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/rules/test_SecurityGroupIngressOpenToWorld.py
+++ b/tests/rules/test_SecurityGroupIngressOpenToWorld.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/rules/test_SecurityGroupMissingEgressRule.py
+++ b/tests/rules/test_SecurityGroupMissingEgressRule.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/rules/test_SecurityGroupOpenToWorldRule.py
+++ b/tests/rules/test_SecurityGroupOpenToWorldRule.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/rules/test_WildcardPoliciesRule.py
+++ b/tests/rules/test_WildcardPoliciesRule.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/test_boto3_client.py
+++ b/tests/test_boto3_client.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018-2019 Skyscanner Ltd
+Copyright 2018-2020 Skyscanner Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License.


### PR DESCRIPTION
Changes from `Copyright 2018-2019 Skyscanner Ltd` to `Copyright 2018-2020 Skyscanner Ltd`