### PR TITLE
Refactor rules name and fix whitelist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ All notable changes to this project will be documented in this file.
 ### Improvements
 - Generate DEFAULT_RULES and BASE_CLASSES using code instead of hardcoding
 ### Fixed
-- Prefix `KMSKeyWildcardPrincipal` and `SecurityGroupIngressOpenToWorld` with `Rule`
 - Whitelist didnot work if it didn't have the `Rule` prefix
+### Breaking changes
+- Prefix `KMSKeyWildcardPrincipal` and `SecurityGroupIngressOpenToWorld` with `Rule`
 
 ## [0.14.2] - 2020-03-04
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.15.0] - 2020-03-24
+### Improvements
+- Generate DEFAULT_RULES and BASE_CLASSES using code instead of hardcoding
+### Fixed
+- Prefix `KMSKeyWildcardPrincipal` and `SecurityGroupIngressOpenToWorld` with `Rule`
+- Whitelist didnot work if it didn't have the `Rule` prefix
+
 ## [0.14.2] - 2020-03-04
 ### Improvements
 - Update dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Whitelist did not work if it didn't have the `Rule` prefix
 ### Breaking changes
 - Sufix `KMSKeyWildcardPrincipal` and `SecurityGroupIngressOpenToWorld` with `Rule`
+- Sufix whitelist constant `FullWildcardPrincipal` and `PartialWildcardPrincipal` with `Rule`
 
 ## [0.14.2] - 2020-03-04
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@ All notable changes to this project will be documented in this file.
 ### Improvements
 - Generate DEFAULT_RULES and BASE_CLASSES using code instead of hardcoding
 ### Fixed
-- Whitelist didnot work if it didn't have the `Rule` prefix
+- Whitelist did not work if it didn't have the `Rule` prefix
 ### Breaking changes
-- Prefix `KMSKeyWildcardPrincipal` and `SecurityGroupIngressOpenToWorld` with `Rule`
+- Sufix `KMSKeyWildcardPrincipal` and `SecurityGroupIngressOpenToWorld` with `Rule`
 
 ## [0.14.2] - 2020-03-04
 ### Improvements

--- a/cfripper/__version__.py
+++ b/cfripper/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (0, 14, 2)
+VERSION = (0, 15, 0)
 
 __version__ = ".".join(map(str, VERSION))

--- a/cfripper/rules/__init__.py
+++ b/cfripper/rules/__init__.py
@@ -23,14 +23,14 @@ from cfripper.rules.cross_account_trust import (
 from cfripper.rules.ebs_volume_has_sse import EBSVolumeHasSSERule
 from cfripper.rules.hardcoded_RDS_password import HardcodedRDSPasswordRule
 from cfripper.rules.iam_roles import IAMRolesOverprivilegedRule, IAMRoleWildcardActionOnPolicyRule
-from cfripper.rules.kms_key_wildcard_principal import KMSKeyWildcardPrincipal
+from cfripper.rules.kms_key_wildcard_principal import KMSKeyWildcardPrincipalRule
 from cfripper.rules.managed_policy_on_user import ManagedPolicyOnUserRule
 from cfripper.rules.policy_on_user import PolicyOnUserRule
 from cfripper.rules.privilege_escalation import PrivilegeEscalationRule
 from cfripper.rules.s3_bucket_policy import S3BucketPolicyPrincipalRule
 from cfripper.rules.s3_public_access import S3BucketPublicReadAclAndListStatementRule, S3BucketPublicReadWriteAclRule
 from cfripper.rules.security_group import (
-    SecurityGroupIngressOpenToWorld,
+    SecurityGroupIngressOpenToWorldRule,
     SecurityGroupMissingEgressRule,
     SecurityGroupOpenToWorldRule,
 )
@@ -47,14 +47,14 @@ DEFAULT_RULES = {
     "CloudFormationAuthenticationRule": CloudFormationAuthenticationRule,
     "CrossAccountTrustRule": CrossAccountTrustRule,
     "EBSVolumeHasSSERule": EBSVolumeHasSSERule,
-    "FullWildcardPrincipal": FullWildcardPrincipalRule,
+    "FullWildcardPrincipalRule": FullWildcardPrincipalRule,
     "HardcodedRDSPasswordRule": HardcodedRDSPasswordRule,
     "IAMRolesOverprivilegedRule": IAMRolesOverprivilegedRule,
     "IAMRoleWildcardActionOnPolicyRule": IAMRoleWildcardActionOnPolicyRule,
     "KMSKeyCrossAccountTrustRule": KMSKeyCrossAccountTrustRule,
-    "KMSKeyWildcardPrincipal": KMSKeyWildcardPrincipal,
+    "KMSKeyWildcardPrincipalRule": KMSKeyWildcardPrincipalRule,
     "ManagedPolicyOnUserRule": ManagedPolicyOnUserRule,
-    "PartialWildcardPrincipal": PartialWildcardPrincipalRule,
+    "PartialWildcardPrincipalRule": PartialWildcardPrincipalRule,
     "PolicyOnUserRule": PolicyOnUserRule,
     "PrivilegeEscalationRule": PrivilegeEscalationRule,
     "S3BucketPolicyPrincipalRule": S3BucketPolicyPrincipalRule,
@@ -62,7 +62,7 @@ DEFAULT_RULES = {
     "S3BucketPublicReadAclAndListStatementRule": S3BucketPublicReadAclAndListStatementRule,
     "S3BucketPublicReadWriteAclRule": S3BucketPublicReadWriteAclRule,
     "S3CrossAccountTrustRule": S3CrossAccountTrustRule,
-    "SecurityGroupIngressOpenToWorld": SecurityGroupIngressOpenToWorld,
+    "SecurityGroupIngressOpenToWorldRule": SecurityGroupIngressOpenToWorldRule,
     "SecurityGroupMissingEgressRule": SecurityGroupMissingEgressRule,
     "SecurityGroupOpenToWorldRule": SecurityGroupOpenToWorldRule,
     "SNSTopicPolicyNotPrincipalRule": SNSTopicPolicyNotPrincipalRule,

--- a/cfripper/rules/__init__.py
+++ b/cfripper/rules/__init__.py
@@ -45,7 +45,7 @@ from cfripper.rules.wildcard_principals import FullWildcardPrincipalRule, Partia
 
 DEFAULT_RULES = {
     rule.__name__: rule
-    for rule in [
+    for rule in {
         CloudFormationAuthenticationRule,
         CrossAccountTrustRule,
         EBSVolumeHasSSERule,
@@ -72,7 +72,7 @@ DEFAULT_RULES = {
         SQSQueuePolicyNotPrincipalRule,
         SQSQueuePolicyPublicRule,
         SQSQueuePolicyWildcardActionRule,
-    ]
+    }
 }
 
-BASE_CLASSES = {rule.__name__: rule for rule in [CrossAccountCheckingRule, PrincipalCheckingRule]}
+BASE_CLASSES = {rule.__name__: rule for rule in {CrossAccountCheckingRule, PrincipalCheckingRule}}

--- a/cfripper/rules/__init__.py
+++ b/cfripper/rules/__init__.py
@@ -45,7 +45,7 @@ from cfripper.rules.wildcard_principals import FullWildcardPrincipalRule, Partia
 
 DEFAULT_RULES = {
     rule.__name__: rule
-    for rule in {
+    for rule in (
         CloudFormationAuthenticationRule,
         CrossAccountTrustRule,
         EBSVolumeHasSSERule,
@@ -72,7 +72,7 @@ DEFAULT_RULES = {
         SQSQueuePolicyNotPrincipalRule,
         SQSQueuePolicyPublicRule,
         SQSQueuePolicyWildcardActionRule,
-    }
+    )
 }
 
-BASE_CLASSES = {rule.__name__: rule for rule in {CrossAccountCheckingRule, PrincipalCheckingRule}}
+BASE_CLASSES = {rule.__name__: rule for rule in (CrossAccountCheckingRule, PrincipalCheckingRule)}

--- a/cfripper/rules/__init__.py
+++ b/cfripper/rules/__init__.py
@@ -75,10 +75,4 @@ DEFAULT_RULES = {
     ]
 }
 
-BASE_CLASSES = {
-    rule.__name__: rule
-    for rule in [
-        CrossAccountCheckingRule,
-        PrincipalCheckingRule,
-    ]
-}
+BASE_CLASSES = {rule.__name__: rule for rule in [CrossAccountCheckingRule, PrincipalCheckingRule]}

--- a/cfripper/rules/__init__.py
+++ b/cfripper/rules/__init__.py
@@ -44,32 +44,41 @@ from cfripper.rules.wildcard_policies import (
 from cfripper.rules.wildcard_principals import FullWildcardPrincipalRule, PartialWildcardPrincipalRule
 
 DEFAULT_RULES = {
-    "CloudFormationAuthenticationRule": CloudFormationAuthenticationRule,
-    "CrossAccountTrustRule": CrossAccountTrustRule,
-    "EBSVolumeHasSSERule": EBSVolumeHasSSERule,
-    "FullWildcardPrincipalRule": FullWildcardPrincipalRule,
-    "HardcodedRDSPasswordRule": HardcodedRDSPasswordRule,
-    "IAMRolesOverprivilegedRule": IAMRolesOverprivilegedRule,
-    "IAMRoleWildcardActionOnPolicyRule": IAMRoleWildcardActionOnPolicyRule,
-    "KMSKeyCrossAccountTrustRule": KMSKeyCrossAccountTrustRule,
-    "KMSKeyWildcardPrincipalRule": KMSKeyWildcardPrincipalRule,
-    "ManagedPolicyOnUserRule": ManagedPolicyOnUserRule,
-    "PartialWildcardPrincipalRule": PartialWildcardPrincipalRule,
-    "PolicyOnUserRule": PolicyOnUserRule,
-    "PrivilegeEscalationRule": PrivilegeEscalationRule,
-    "S3BucketPolicyPrincipalRule": S3BucketPolicyPrincipalRule,
-    "S3BucketPolicyWildcardActionRule": S3BucketPolicyWildcardActionRule,
-    "S3BucketPublicReadAclAndListStatementRule": S3BucketPublicReadAclAndListStatementRule,
-    "S3BucketPublicReadWriteAclRule": S3BucketPublicReadWriteAclRule,
-    "S3CrossAccountTrustRule": S3CrossAccountTrustRule,
-    "SecurityGroupIngressOpenToWorldRule": SecurityGroupIngressOpenToWorldRule,
-    "SecurityGroupMissingEgressRule": SecurityGroupMissingEgressRule,
-    "SecurityGroupOpenToWorldRule": SecurityGroupOpenToWorldRule,
-    "SNSTopicPolicyNotPrincipalRule": SNSTopicPolicyNotPrincipalRule,
-    "SNSTopicPolicyWildcardActionRule": SNSTopicPolicyWildcardActionRule,
-    "SQSQueuePolicyNotPrincipalRule": SQSQueuePolicyNotPrincipalRule,
-    "SQSQueuePolicyPublicRule": SQSQueuePolicyPublicRule,
-    "SQSQueuePolicyWildcardActionRule": SQSQueuePolicyWildcardActionRule,
+    rule.__name__: rule
+    for rule in [
+        CloudFormationAuthenticationRule,
+        CrossAccountTrustRule,
+        EBSVolumeHasSSERule,
+        FullWildcardPrincipalRule,
+        HardcodedRDSPasswordRule,
+        IAMRolesOverprivilegedRule,
+        IAMRoleWildcardActionOnPolicyRule,
+        KMSKeyCrossAccountTrustRule,
+        KMSKeyWildcardPrincipalRule,
+        ManagedPolicyOnUserRule,
+        PartialWildcardPrincipalRule,
+        PolicyOnUserRule,
+        PrivilegeEscalationRule,
+        S3BucketPolicyPrincipalRule,
+        S3BucketPolicyWildcardActionRule,
+        S3BucketPublicReadAclAndListStatementRule,
+        S3BucketPublicReadWriteAclRule,
+        S3CrossAccountTrustRule,
+        SecurityGroupIngressOpenToWorldRule,
+        SecurityGroupMissingEgressRule,
+        SecurityGroupOpenToWorldRule,
+        SNSTopicPolicyNotPrincipalRule,
+        SNSTopicPolicyWildcardActionRule,
+        SQSQueuePolicyNotPrincipalRule,
+        SQSQueuePolicyPublicRule,
+        SQSQueuePolicyWildcardActionRule,
+    ]
 }
 
-BASE_CLASSES = {"CrossAccountCheckingRule": CrossAccountCheckingRule, "PrincipalCheckingRule": PrincipalCheckingRule}
+BASE_CLASSES = {
+    rule.__name__: rule
+    for rule in [
+        CrossAccountCheckingRule,
+        PrincipalCheckingRule,
+    ]
+}

--- a/cfripper/rules/kms_key_wildcard_principal.py
+++ b/cfripper/rules/kms_key_wildcard_principal.py
@@ -12,7 +12,7 @@ under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-__all__ = ["KMSKeyWildcardPrincipal"]
+__all__ = ["KMSKeyWildcardPrincipalRule"]
 import logging
 import re
 from typing import Dict, Optional
@@ -27,7 +27,7 @@ from cfripper.rules.base_rules import Rule
 logger = logging.getLogger(__file__)
 
 
-class KMSKeyWildcardPrincipal(Rule):
+class KMSKeyWildcardPrincipalRule(Rule):
     """
     Check for wildcards in principals in KMS Policies.
     """

--- a/cfripper/rules/security_group.py
+++ b/cfripper/rules/security_group.py
@@ -12,7 +12,7 @@ under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-__all__ = ["SecurityGroupOpenToWorldRule", "SecurityGroupIngressOpenToWorld", "SecurityGroupMissingEgressRule"]
+__all__ = ["SecurityGroupOpenToWorldRule", "SecurityGroupIngressOpenToWorldRule", "SecurityGroupMissingEgressRule"]
 
 from typing import Dict, Optional
 
@@ -86,7 +86,7 @@ class SecurityGroupOpenToWorldRule(Rule):
         return result
 
 
-class SecurityGroupIngressOpenToWorld(SecurityGroupOpenToWorldRule):
+class SecurityGroupIngressOpenToWorldRule(SecurityGroupOpenToWorldRule):
     """
     Checks if a security group has a CIDR open to world on ingress.
 

--- a/tests/rules/test_SecurityGroupIngressOpenToWorld.py
+++ b/tests/rules/test_SecurityGroupIngressOpenToWorld.py
@@ -15,7 +15,7 @@ specific language governing permissions and limitations under the License.
 from pytest import fixture
 
 from cfripper.config.config import Config
-from cfripper.rules import SecurityGroupIngressOpenToWorld
+from cfripper.rules import SecurityGroupIngressOpenToWorldRule
 from tests.utils import get_cfmodel_from
 
 
@@ -25,7 +25,7 @@ def bad_template():
 
 
 def test_failures_are_raised(bad_template):
-    rule = SecurityGroupIngressOpenToWorld(Config())
+    rule = SecurityGroupIngressOpenToWorldRule(Config())
     result = rule.invoke(bad_template)
 
     assert not result.valid

--- a/tests/rules/test_SecurityGroupIngressOpenToWorld.py
+++ b/tests/rules/test_SecurityGroupIngressOpenToWorld.py
@@ -31,7 +31,7 @@ def test_failures_are_raised(bad_template):
     assert not result.valid
     assert len(result.failed_rules) == 2
     assert len(result.failed_monitored_rules) == 0
-    assert result.failed_rules[0].rule == "SecurityGroupIngressOpenToWorld"
+    assert result.failed_rules[0].rule == "SecurityGroupIngressOpenToWorldRule"
     assert result.failed_rules[0].reason == "Port 46 open to the world in security group 'securityGroupIngress1'"
-    assert result.failed_rules[1].rule == "SecurityGroupIngressOpenToWorld"
+    assert result.failed_rules[1].rule == "SecurityGroupIngressOpenToWorldRule"
     assert result.failed_rules[1].reason == "Port 46 open to the world in security group 'securityGroupIngress2'"


### PR DESCRIPTION
### Improvements
- Generate DEFAULT_RULES and BASE_CLASSES using code instead of hardcoding
### Fixed
- Whitelist did not work if it didn't have the `Rule` prefix
### Breaking changes
- Sufix `KMSKeyWildcardPrincipal` and `SecurityGroupIngressOpenToWorld` with `Rule`
- Sufix whitelist constant `FullWildcardPrincipal` and `PartialWildcardPrincipal` with `Rule`