### PR TITLE
Improve scope of Sec Group Ingress and Open Ports rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [0.15.1] - 2020-03-26
 ### Improvements
-- `SecurityGroupOpenToWorldRule` and `SecurityGroupIngressOpenToWorldRule` now more accurately setup to block
+- `SecurityGroupOpenToWorldRule` and `SecurityGroupIngressOpenToWorldRule` are now more accurately scoped to block
 potentially public CIDR ranges. It it utilising the latest `pycfmodel` release (0.7.0).
 
 ## [0.15.0] - 2020-03-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.15.1] - 2020-03-26
+### Improvements
+- `SecurityGroupOpenToWorldRule` and `SecurityGroupIngressOpenToWorldRule` now more accurately setup to block
+potentially public CIDR ranges. It it utilising the latest `pycfmodel` release (0.7.0).
+
 ## [0.14.2] - 2020-03-04
 ### Improvements
 - Update dependencies

--- a/cfripper/__version__.py
+++ b/cfripper/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (0, 14, 2)
+VERSION = (0, 15, 1)
 
 __version__ = ".".join(map(str, VERSION))

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,16 +4,16 @@
 #
 #    make freeze
 #
-boto3==1.12.13            # via cfripper (setup.py)
+boto3==1.12.13
 botocore==1.15.13         # via boto3, s3transfer
-cfn-flip==1.2.2           # via cfripper (setup.py)
+cfn-flip==1.2.2
 click==7.0                # via cfn-flip
 docutils==0.15.2          # via botocore
 jmespath==0.9.5           # via boto3, botocore
-pycfmodel==0.6.4          # via cfripper (setup.py)
+pycfmodel==0.7.0
 pydantic==1.4             # via pycfmodel
 python-dateutil==2.8.1    # via botocore
-pyyaml==5.3               # via cfn-flip, cfripper (setup.py)
+pyyaml==5.3
 s3transfer==0.3.3         # via boto3
 six==1.14.0               # via cfn-flip, python-dateutil
 urllib3==1.25.8           # via botocore

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from cfripper.__version__ import __version__
 
 project_root_path = Path(__file__).parent
 
-install_requires = ["boto3>=1.4.7,<2", "PyYAML>=4.2b1", "pycfmodel>=0.5.1", "cfn_flip>=1.2.0"]
+install_requires = ["boto3>=1.4.7,<2", "PyYAML>=4.2b1", "pycfmodel>=0.7.0", "cfn_flip>=1.2.0"]
 
 dev_requires = [
     "black==19.10b0",

--- a/tests/rules/test_SecurityGroupIngressOpenToWorld.py
+++ b/tests/rules/test_SecurityGroupIngressOpenToWorld.py
@@ -43,6 +43,6 @@ def test_failures_are_raised(bad_template):
 
 
 def test_valid_security_group_ingress(good_template):
-    rule = SecurityGroupIngressOpenToWorld(Config())
+    rule = SecurityGroupIngressOpenToWorldRule(Config())
     result = rule.invoke(good_template)
     assert result.valid

--- a/tests/rules/test_SecurityGroupIngressOpenToWorld.py
+++ b/tests/rules/test_SecurityGroupIngressOpenToWorld.py
@@ -24,6 +24,11 @@ def bad_template():
     return get_cfmodel_from("rules/SecurityGroupIngressOpenToWorld/bad_template.json").resolve()
 
 
+@fixture()
+def good_template():
+    return get_cfmodel_from("rules/SecurityGroupIngressOpenToWorld/good_template.json").resolve()
+
+
 def test_failures_are_raised(bad_template):
     rule = SecurityGroupIngressOpenToWorld(Config())
     result = rule.invoke(bad_template)
@@ -35,3 +40,9 @@ def test_failures_are_raised(bad_template):
     assert result.failed_rules[0].reason == "Port 46 open to the world in security group 'securityGroupIngress1'"
     assert result.failed_rules[1].rule == "SecurityGroupIngressOpenToWorld"
     assert result.failed_rules[1].reason == "Port 46 open to the world in security group 'securityGroupIngress2'"
+
+
+def test_valid_security_group_ingress(good_template):
+    rule = SecurityGroupIngressOpenToWorld(Config())
+    result = rule.invoke(good_template)
+    assert result.valid

--- a/tests/test_templates/rules/SecurityGroupIngressOpenToWorld/good_template.json
+++ b/tests/test_templates/rules/SecurityGroupIngressOpenToWorld/good_template.json
@@ -4,7 +4,7 @@
       "Type": "AWS::EC2::SecurityGroupIngress",
       "Properties": {
         "GroupId": "sg-12341234",
-        "CidrIp": "11.0.0.0/8",
+        "CidrIp": "172.16.0.0/12",
         "FromPort": 46,
         "ToPort": 46,
         "IpProtocol": "tcp"
@@ -14,7 +14,7 @@
       "Type": "AWS::EC2::SecurityGroupIngress",
       "Properties": {
         "GroupId": "sg-12341234",
-        "CidrIpv6": "::/0",
+        "CidrIpv6": "fd00::/8",
         "FromPort": 46,
         "ToPort": 46,
         "IpProtocol": "tcp"

--- a/tests/test_templates/rules/SecurityGroupOpenToWorldRule/invalid_security_group_multiple_statements.json
+++ b/tests/test_templates/rules/SecurityGroupOpenToWorldRule/invalid_security_group_multiple_statements.json
@@ -14,7 +14,7 @@
           },
           {
             "IpProtocol": "tcp",
-            "CidrIp": "0.0.0.0/0",
+            "CidrIp": "172.0.0.0/8",
             "FromPort": 9090,
             "ToPort": 9090
           }

--- a/tests/test_templates/rules/SecurityGroupOpenToWorldRule/invalid_security_group_range.json
+++ b/tests/test_templates/rules/SecurityGroupOpenToWorldRule/invalid_security_group_range.json
@@ -8,7 +8,7 @@
         "SecurityGroupIngress": [
           {
             "IpProtocol": "tcp",
-            "CidrIp": "0.0.0.0/0",
+            "CidrIp": "11.0.0.0/8",
             "FromPort": 0,
             "ToPort": 100
           }


### PR DESCRIPTION
This PR uses the latest updates in `pycfmodel` to improve the current rules for checking publicly open security groups. Before, the rule only blocked on `/0` CIDR blocks. It now uses the Python `ipaddress` library to natively check if an CIDR block `is_global` or not.

|        IP        |    Before   |    After    |
|:---------------:|:-----------:|:-----------:|
|   `0.0.0.0/0`   |   blocked   |   blocked   |
|   `10.0.0.0/8`  | not blocked | not blocked |
|   `11.0.0.0/8`  | not blocked |   blocked   |
|      `::/0`     |   blocked   |   blocked   |
| `172.16.0.0/12` | not blocked | not blocked |
|     `fa::/8`    | not blocked |   blocked   |