### PR TITLE
Implement filters in CrossAccount Rules + Refactor of these inherit classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.17.0] - 2020-03-27
+### Improvements
+- `CrossAccountCheckingRule`, `CrossAccountTrustRule`, `S3CrossAccountTrustRule` and `KMSKeyCrossAccountTrustRule` include support for filters.
+### Breaking changes
+- `CrossAccountCheckingRule` now includes the invoke method. Statements of PolicyDocument are now analysed using `RESOURCE_TYPE` and `PROPERTY_WITH_POLICYDOCUMENT` class variables. 
+
 ## [0.16.0] - 2020-03-27
 ### Improvements
 - Add new `RuleConfig`, allows to overwrite the default behaviour of the rule changing rule mode and risk value.

--- a/cfripper/__version__.py
+++ b/cfripper/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (0, 16, 0)
+VERSION = (0, 17, 0)
 
 __version__ = ".".join(map(str, VERSION))

--- a/cfripper/rules/cross_account_trust.py
+++ b/cfripper/rules/cross_account_trust.py
@@ -157,8 +157,8 @@ class S3CrossAccountTrustRule(CrossAccountCheckingRule):
     Filters context:
         | Parameter   | Type             | Description                                                    |
         |:-----------:|:----------------:|:--------------------------------------------------------------:|
-        |`config`     | str         | `config` variable available inside the rule                    |
-        |`extras`     | str         | `extras` variable available inside the rule                    |
+        |`config`     | str              | `config` variable available inside the rule                    |
+        |`extras`     | str              | `extras` variable available inside the rule                    |
         |`logical_id` | str              | ID used in Cloudformation to refer the resource being analysed |
         |`resource`   | `S3BucketPolicy` | Resource that is being addressed                               |
         |`statement`  | `Statement`      | Statement being checked found in the Resource                  |

--- a/docs/macros.py
+++ b/docs/macros.py
@@ -36,7 +36,7 @@ def define_env(env):
 
                 else:
                     content += f"\n#### {paragraph_title}\n"
-                    content += paragraph_text
+                    content += f"{paragraph_text}\n"
 
             results.append((klass.__name__, content))
 

--- a/docs/rule_config.md
+++ b/docs/rule_config.md
@@ -14,7 +14,10 @@ The object accepts a reason parameter to say why that filter exists.
 !!! warning
     Only available for the following rules: 
     
-      - Not supported yet
+      - CrossAccountCheckingRule
+      - CrossAccountTrustRule
+      - S3CrossAccountTrustRule
+      - KMSKeyCrossAccountTrustRule
       
 ### Filter preference
 


### PR DESCRIPTION
### Improvements
- `CrossAccountCheckingRule`, `CrossAccountTrustRule`, `S3CrossAccountTrustRule` and `KMSKeyCrossAccountTrustRule` include support for filters.
### Breaking changes
- `CrossAccountCheckingRule` now includes the invoke method. Statements of PolicyDocument are now analysed using `RESOURCE_TYPE` and `PROPERTY_WITH_POLICYDOCUMENT` class variables. 
