### PR TITLE
Improve message and documentation for security group rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.17.2] - 2020-04-01
+### Improvements
+- Improved message for users when failing the `SecurityGroupOpenToWorldRule` and `SecurityGroupIngressOpenToWorldRule` rules.
+- Improved documentation for the above rules, including styling fixes which have now been tested.
+
 ## [0.17.1] - 2020-03-30
 ### Improvements
 - Add `exists` and `empty` functions to filters

--- a/cfripper/__version__.py
+++ b/cfripper/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (0, 17, 1)
+VERSION = (0, 17, 2)
 
 __version__ = ".".join(map(str, VERSION))

--- a/tests/rules/test_SecurityGroupIngressOpenToWorld.py
+++ b/tests/rules/test_SecurityGroupIngressOpenToWorld.py
@@ -23,9 +23,14 @@ def test_failures_are_raised(bad_template):
     assert len(result.failed_rules) == 2
     assert len(result.failed_monitored_rules) == 0
     assert result.failed_rules[0].rule == "SecurityGroupIngressOpenToWorldRule"
-    assert result.failed_rules[0].reason == "Port 46 open to the world in security group 'securityGroupIngress1'"
+    assert (
+        result.failed_rules[0].reason
+        == "Port 46 open to public IPs: (11.0.0.0/8) in security group 'securityGroupIngress1'"
+    )
     assert result.failed_rules[1].rule == "SecurityGroupIngressOpenToWorldRule"
-    assert result.failed_rules[1].reason == "Port 46 open to the world in security group 'securityGroupIngress2'"
+    assert (
+        result.failed_rules[1].reason == "Port 46 open to public IPs: (::/0) in security group 'securityGroupIngress2'"
+    )
 
 
 def test_valid_security_group_ingress(good_template):

--- a/tests/rules/test_SecurityGroupOpenToWorldRule.py
+++ b/tests/rules/test_SecurityGroupOpenToWorldRule.py
@@ -47,7 +47,7 @@ def test_security_group_type_slash0(security_group_type_slash0):
 
     assert not result.valid
     assert result.failed_rules[0].rule == "SecurityGroupOpenToWorldRule"
-    assert result.failed_rules[0].reason == "Port 22 open to the world in security group 'SecurityGroup'"
+    assert result.failed_rules[0].reason == "Port 22 open to public IPs: (0.0.0.0/0) in security group 'SecurityGroup'"
 
 
 def test_valid_security_group_not_slash0(valid_security_group_not_slash0):
@@ -83,7 +83,7 @@ def test_invalid_security_group_cidripv6(invalid_security_group_cidripv6):
 
     assert not result.valid
     assert result.failed_rules[0].rule == "SecurityGroupOpenToWorldRule"
-    assert result.failed_rules[0].reason == "Port 22 open to the world in security group 'SecurityGroup'"
+    assert result.failed_rules[0].reason == "Port 22 open to public IPs: (::/0) in security group 'SecurityGroup'"
 
 
 def test_invalid_security_group_range(invalid_security_group_range):
@@ -92,7 +92,7 @@ def test_invalid_security_group_range(invalid_security_group_range):
 
     assert not result.valid
     assert result.failed_rules[0].rule == "SecurityGroupOpenToWorldRule"
-    assert result.failed_rules[0].reason == "Port 0 open to the world in security group 'SecurityGroup'"
+    assert result.failed_rules[0].reason == "Port 0 open to public IPs: (11.0.0.0/8) in security group 'SecurityGroup'"
 
 
 def test_invalid_security_group_multiple_statements(invalid_security_group_multiple_statements):
@@ -101,4 +101,6 @@ def test_invalid_security_group_multiple_statements(invalid_security_group_multi
 
     assert not result.valid
     assert result.failed_rules[0].rule == "SecurityGroupOpenToWorldRule"
-    assert result.failed_rules[0].reason == "Port 9090 open to the world in security group 'SecurityGroup'"
+    assert (
+        result.failed_rules[0].reason == "Port 9090 open to public IPs: (172.0.0.0/8) in security group 'SecurityGroup'"
+    )


### PR DESCRIPTION
## [0.17.2] - 2020-04-01
### Improvements
- Improved message for users when failing the `SecurityGroupOpenToWorldRule` and `SecurityGroupIngressOpenToWorldRule` rules.
- Improved documentation for the above rules, including styling fixes which have now been tested.