### PR TITLE
Fix for add_failure on cross_account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.18.1] - 2020-04-14
+### Fixed
+- `CrossAccountCheckingRule` calling `add_failure_to_result` on `UNDEFINED_` was missing context variable.
+
 ## [0.18.0] - 2020-04-07
 ### Improvements
 - `EC2SecurityGroupIngressOpenToWorldRule`, `EC2SecurityGroupMissingEgressRule` and `EC2SecurityGroupOpenToWorldRule` include support for filters.

--- a/cfripper/__version__.py
+++ b/cfripper/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (0, 18, 0)
+VERSION = (0, 18, 1)
 
 __version__ = ".".join(map(str, VERSION))

--- a/cfripper/rules/cross_account_trust.py
+++ b/cfripper/rules/cross_account_trust.py
@@ -90,6 +90,7 @@ class CrossAccountCheckingRule(PrincipalCheckingRule):
                             self.REASON.format(logical_id, principal),
                             rule_mode=RuleMode.DEBUG,
                             resource_ids={logical_id},
+                            context=filters_available_context,
                         )
                     else:
                         self.add_failure_to_result(


### PR DESCRIPTION
### Fixed
- `CrossAccountCheckingRule` calling `add_failure_to_result` on `UNDEFINED_` was missing context variable.
