### PR TITLE
Update default rule modes to Blocking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.19.0] - 2020-05-21
+### Breaking changes
+- `rule_mode` is now `BLOCKING` for all Rules.
+
 ## [0.18.1] - 2020-04-14
 ### Fixed
 - `CrossAccountCheckingRule` calling `add_failure_to_result` on `UNDEFINED_` was missing context variable.

--- a/cfripper/__version__.py
+++ b/cfripper/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (0, 18, 1)
+VERSION = (0, 19, 0)
 
 __version__ = ".".join(map(str, VERSION))

--- a/cfripper/main.py
+++ b/cfripper/main.py
@@ -144,7 +144,7 @@ def get_template(event):
             if event.get("stack_template_url"):
                 template = boto3_client.download_template_to_dictionary(event["stack_template_url"])
             else:
-                logger.info(f"stack_template_url not available")
+                logger.info("stack_template_url not available")
         except Exception:
             logger.exception(
                 f"Error calling download_template_to_dictionary for: {stack_name} on {account_id} - {region}"

--- a/cfripper/model/result.py
+++ b/cfripper/model/result.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel, Extra
+from pydantic.typing import AbstractSetIntStr, DictIntStrAny
 
 from cfripper.model.enums import RuleMode
 
@@ -46,8 +47,8 @@ class Result(BaseModel):
     def dict(
         self,
         *,
-        include: Union["AbstractSetIntStr", "DictIntStrAny"] = None,
-        exclude: Union["AbstractSetIntStr", "DictIntStrAny"] = None,
+        include: Union[AbstractSetIntStr, DictIntStrAny] = None,
+        exclude: Union[AbstractSetIntStr, DictIntStrAny] = None,
         by_alias: bool = False,
         skip_defaults: bool = None,
         exclude_unset: bool = False,

--- a/cfripper/model/result.py
+++ b/cfripper/model/result.py
@@ -1,9 +1,11 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel, Extra
-from pydantic.typing import AbstractSetIntStr, DictIntStrAny
 
 from cfripper.model.enums import RuleMode
+
+if TYPE_CHECKING:
+    from pydantic.typing import AbstractSetIntStr, DictIntStrAny
 
 
 class Failure(BaseModel):
@@ -47,8 +49,8 @@ class Result(BaseModel):
     def dict(
         self,
         *,
-        include: Union[AbstractSetIntStr, DictIntStrAny] = None,
-        exclude: Union[AbstractSetIntStr, DictIntStrAny] = None,
+        include: Union["AbstractSetIntStr", "DictIntStrAny"] = None,
+        exclude: Union["AbstractSetIntStr", "DictIntStrAny"] = None,
         by_alias: bool = False,
         skip_defaults: bool = None,
         exclude_unset: bool = False,

--- a/cfripper/rules/cloudformation_authentication.py
+++ b/cfripper/rules/cloudformation_authentication.py
@@ -4,7 +4,7 @@ from typing import Dict, Optional
 
 from pycfmodel.model.cf_model import CFModel
 
-from cfripper.model.enums import RuleGranularity, RuleMode
+from cfripper.model.enums import RuleGranularity
 from cfripper.model.result import Result
 from cfripper.rules.base_rules import Rule
 
@@ -40,7 +40,6 @@ class CloudFormationAuthenticationRule(Rule):
     """
 
     REASON = "Hardcoded credentials in {}"
-    RULE_MODE = RuleMode.MONITOR
     GRANULARITY = RuleGranularity.RESOURCE
 
     def invoke(self, cfmodel: CFModel, extras: Optional[Dict] = None) -> Result:

--- a/cfripper/rules/ebs_volume_has_sse.py
+++ b/cfripper/rules/ebs_volume_has_sse.py
@@ -4,7 +4,7 @@ from typing import Dict, Optional
 
 from pycfmodel.model.cf_model import CFModel
 
-from cfripper.model.enums import RuleGranularity, RuleMode
+from cfripper.model.enums import RuleGranularity
 from cfripper.model.result import Result
 from cfripper.rules.base_rules import Rule
 
@@ -35,7 +35,6 @@ class EBSVolumeHasSSERule(Rule):
     """
 
     REASON = "EBS volume {} should have server-side encryption enabled"
-    RULE_MODE = RuleMode.MONITOR
     GRANULARITY = RuleGranularity.RESOURCE
 
     def invoke(self, cfmodel: CFModel, extras: Optional[Dict] = None) -> Result:

--- a/cfripper/rules/ec2_security_group.py
+++ b/cfripper/rules/ec2_security_group.py
@@ -13,7 +13,7 @@ from pycfmodel.model.resources.properties.security_group_ingress_prop import Sec
 from pycfmodel.model.resources.security_group import SecurityGroup
 from pycfmodel.model.resources.security_group_ingress import SecurityGroupIngress, SecurityGroupIngressProperties
 
-from cfripper.model.enums import RuleGranularity, RuleMode
+from cfripper.model.enums import RuleGranularity
 from cfripper.model.result import Result
 from cfripper.rules.base_rules import Rule
 
@@ -314,7 +314,6 @@ class EC2SecurityGroupMissingEgressRule(Rule):
         "Missing egress rule in {} means all traffic is allowed outbound. Make this explicit if it is desired "
         "configuration"
     )
-    RULE_MODE = RuleMode.DEBUG
 
     def invoke(self, cfmodel: CFModel, extras: Optional[Dict] = None) -> Result:
         result = Result()

--- a/cfripper/rules/iam_roles.py
+++ b/cfripper/rules/iam_roles.py
@@ -7,7 +7,7 @@ from pycfmodel.model.resources.iam_managed_policy import IAMManagedPolicy
 from pycfmodel.model.resources.iam_role import IAMRole
 
 from cfripper.config.regex import REGEX_IS_STAR, REGEX_WILDCARD_POLICY_ACTION
-from cfripper.model.enums import RuleGranularity, RuleMode
+from cfripper.model.enums import RuleGranularity
 from cfripper.model.result import Result
 from cfripper.rules.base_rules import Rule
 
@@ -67,7 +67,6 @@ class IAMRoleWildcardActionOnPolicyRule(Rule):
 
     GRANULARITY = RuleGranularity.RESOURCE
     REASON = "IAM role {} should not allow a `*` action on its {}"
-    RULE_MODE = RuleMode.DEBUG
 
     def invoke(self, cfmodel: CFModel, extras: Optional[Dict] = None) -> Result:
         result = Result()

--- a/cfripper/rules/managed_policy_on_user.py
+++ b/cfripper/rules/managed_policy_on_user.py
@@ -5,7 +5,7 @@ from typing import Dict, Optional
 from pycfmodel.model.cf_model import CFModel
 from pycfmodel.model.resources.iam_managed_policy import IAMManagedPolicy
 
-from cfripper.model.enums import RuleGranularity, RuleMode
+from cfripper.model.enums import RuleGranularity
 from cfripper.model.result import Result
 from cfripper.rules.base_rules import Rule
 
@@ -63,7 +63,6 @@ class ManagedPolicyOnUserRule(Rule):
     """
 
     REASON = "IAM managed policy {} should not apply directly to users. Should be on group"
-    RULE_MODE = RuleMode.MONITOR
     GRANULARITY = RuleGranularity.RESOURCE
 
     def invoke(self, cfmodel: CFModel, extras: Optional[Dict] = None) -> Result:

--- a/cfripper/rules/policy_on_user.py
+++ b/cfripper/rules/policy_on_user.py
@@ -5,7 +5,7 @@ from typing import Dict, Optional
 from pycfmodel.model.cf_model import CFModel
 from pycfmodel.model.resources.iam_policy import IAMPolicy
 
-from cfripper.model.enums import RuleGranularity, RuleMode
+from cfripper.model.enums import RuleGranularity
 from cfripper.model.result import Result
 from cfripper.rules.base_rules import Rule
 
@@ -64,7 +64,6 @@ class PolicyOnUserRule(Rule):
 
     GRANULARITY = RuleGranularity.RESOURCE
     REASON = "IAM policy {} should not apply directly to users. Should be on group"
-    RULE_MODE = RuleMode.MONITOR
 
     def invoke(self, cfmodel: CFModel, extras: Optional[Dict] = None) -> Result:
         result = Result()

--- a/cfripper/rules/s3_bucket_policy.py
+++ b/cfripper/rules/s3_bucket_policy.py
@@ -5,7 +5,7 @@ from typing import Dict, Optional
 from pycfmodel.model.cf_model import CFModel
 from pycfmodel.model.resources.s3_bucket_policy import S3BucketPolicy
 
-from cfripper.model.enums import RuleGranularity, RuleMode, RuleRisk
+from cfripper.model.enums import RuleGranularity, RuleRisk
 from cfripper.model.result import Result
 from cfripper.model.utils import get_account_id_from_principal
 from cfripper.rules.base_rules import PrincipalCheckingRule
@@ -27,7 +27,6 @@ class S3BucketPolicyPrincipalRule(PrincipalCheckingRule):
 
     GRANULARITY = RuleGranularity.RESOURCE
     REASON = "S3 Bucket {} policy has non-whitelisted principals {}"
-    RULE_MODE = RuleMode.BLOCKING
     RISK_VALUE = RuleRisk.HIGH
 
     def invoke(self, cfmodel: CFModel, extras: Optional[Dict] = None) -> Result:

--- a/cfripper/rules/s3_public_access.py
+++ b/cfripper/rules/s3_public_access.py
@@ -7,7 +7,7 @@ from typing import Dict, Optional
 from pycfmodel.model.cf_model import CFModel
 from pycfmodel.model.resources.s3_bucket_policy import S3BucketPolicy
 
-from cfripper.model.enums import RuleGranularity, RuleMode, RuleRisk
+from cfripper.model.enums import RuleGranularity, RuleRisk
 from cfripper.model.result import Result
 from cfripper.rules.base_rules import Rule
 
@@ -26,7 +26,6 @@ class S3BucketPublicReadAclAndListStatementRule(Rule):
 
     GRANULARITY = RuleGranularity.RESOURCE
     REASON = "S3 Bucket {} should not have a public read acl and list bucket statement"
-    RULE_MODE = RuleMode.DEBUG
 
     def invoke(self, cfmodel: CFModel, extras: Optional[Dict] = None) -> Result:
         result = Result()

--- a/cfripper/rules/sns_topic_policy_not_principal.py
+++ b/cfripper/rules/sns_topic_policy_not_principal.py
@@ -5,7 +5,7 @@ from typing import Dict, Optional
 from pycfmodel.model.cf_model import CFModel
 from pycfmodel.model.resources.sns_topic_policy import SNSTopicPolicy
 
-from cfripper.model.enums import RuleGranularity, RuleMode
+from cfripper.model.enums import RuleGranularity
 from cfripper.model.result import Result
 from cfripper.rules.base_rules import Rule
 
@@ -22,7 +22,6 @@ class SNSTopicPolicyNotPrincipalRule(Rule):
 
     GRANULARITY = RuleGranularity.RESOURCE
     REASON = "SNS Topic {} policy should not allow Allow and NotPrincipal at the same time"
-    RULE_MODE = RuleMode.MONITOR
 
     def invoke(self, cfmodel: CFModel, extras: Optional[Dict] = None) -> Result:
         result = Result()

--- a/cfripper/rules/sqs_queue_policy.py
+++ b/cfripper/rules/sqs_queue_policy.py
@@ -7,7 +7,7 @@ from pycfmodel.model.cf_model import CFModel
 from pycfmodel.model.resources.sqs_queue_policy import SQSQueuePolicy
 
 from cfripper.config.regex import REGEX_HAS_STAR_OR_STAR_AFTER_COLON
-from cfripper.model.enums import RuleGranularity, RuleMode, RuleRisk
+from cfripper.model.enums import RuleGranularity, RuleRisk
 from cfripper.model.result import Result
 from cfripper.rules.base_rules import Rule
 
@@ -26,7 +26,6 @@ class SQSQueuePolicyNotPrincipalRule(Rule):
 
     GRANULARITY = RuleGranularity.RESOURCE
     REASON = "SQS Queue {} policy should not allow Allow and NotPrincipal at the same time"
-    RULE_MODE = RuleMode.MONITOR
 
     def invoke(self, cfmodel: CFModel, extras: Optional[Dict] = None) -> Result:
         result = Result()

--- a/cfripper/rules/wildcard_policies.py
+++ b/cfripper/rules/wildcard_policies.py
@@ -14,7 +14,7 @@ from pycfmodel.model.resources.sns_topic_policy import SNSTopicPolicy
 from pycfmodel.model.resources.sqs_queue_policy import SQSQueuePolicy
 
 from cfripper.config.regex import REGEX_HAS_STAR_OR_STAR_AFTER_COLON
-from cfripper.model.enums import RuleGranularity, RuleMode
+from cfripper.model.enums import RuleGranularity
 from cfripper.model.result import Result
 from cfripper.rules.base_rules import Rule
 
@@ -30,7 +30,6 @@ class GenericWildcardPolicyRule(Rule):
 
     REASON = "The {} {} should not allow a `*` action"
 
-    RULE_MODE = RuleMode.DEBUG
     GRANULARITY = RuleGranularity.RESOURCE
 
     AWS_RESOURCE: Type[Resource] = None

--- a/cfripper/rules/wildcard_principals.py
+++ b/cfripper/rules/wildcard_principals.py
@@ -96,7 +96,6 @@ class PartialWildcardPrincipalRule(GenericWildcardPrincipalRule):
 
     REASON_WILCARD_PRINCIPAL = "{} should not allow wildcard in principals or account-wide principals (principal: '{}')"
 
-    RULE_MODE = RuleMode.MONITOR
     RISK_VALUE = RuleRisk.MEDIUM
     """
     Will catch:

--- a/cfripper/rules/wildcard_principals.py
+++ b/cfripper/rules/wildcard_principals.py
@@ -14,7 +14,7 @@ from pycfmodel.model.resources.sns_topic_policy import SNSTopicPolicy
 from pycfmodel.model.resources.sqs_queue_policy import SQSQueuePolicy
 
 from cfripper.config.regex import REGEX_FULL_WILDCARD_PRINCIPAL
-from cfripper.model.enums import RuleGranularity, RuleMode, RuleRisk
+from cfripper.model.enums import RuleGranularity, RuleRisk
 from cfripper.model.result import Result
 from cfripper.rules.base_rules import PrincipalCheckingRule
 

--- a/cfripper/rules/wildcard_principals.py
+++ b/cfripper/rules/wildcard_principals.py
@@ -28,7 +28,6 @@ class GenericWildcardPrincipalRule(PrincipalCheckingRule):
 
     REASON_WILCARD_PRINCIPAL = "{} should not allow wildcard in principals or account-wide principals (principal: '{}')"
     REASON_NOT_ALLOWED_PRINCIPAL = "{} contains an unknown principal: {}"
-    RULE_MODE = RuleMode.MONITOR
     GRANULARITY = RuleGranularity.RESOURCE
 
     IAM_PATTERN = re.compile(r"arn:aws:iam::(\d*|\*):.*")
@@ -122,7 +121,6 @@ class FullWildcardPrincipalRule(GenericWildcardPrincipalRule):
 
     REASON_WILCARD_PRINCIPAL = "{} should not allow wildcards in principals (principal: '{}')"
 
-    RULE_MODE = RuleMode.BLOCKING
     RISK_VALUE = RuleRisk.HIGH
 
     FULL_REGEX = REGEX_FULL_WILDCARD_PRINCIPAL

--- a/tests/rules/test_CloudFormationAuthenticationRule.py
+++ b/tests/rules/test_CloudFormationAuthenticationRule.py
@@ -32,11 +32,11 @@ def test_failures_are_raised(bad_template):
     rule = CloudFormationAuthenticationRule(None)
     result = rule.invoke(bad_template)
 
-    assert result.valid
-    assert len(result.failed_rules) == 0
-    assert len(result.failed_monitored_rules) == 1
-    assert result.failed_monitored_rules[0].rule == "CloudFormationAuthenticationRule"
-    assert result.failed_monitored_rules[0].reason == "Hardcoded credentials in EC2I4LBA1"
+    assert not result.valid
+    assert len(result.failed_rules) == 1
+    assert len(result.failed_monitored_rules) == 0
+    assert result.failed_rules[0].rule == "CloudFormationAuthenticationRule"
+    assert result.failed_rules[0].reason == "Hardcoded credentials in EC2I4LBA1"
 
 
 def test_rule_ignores_where_auth_not_mentioned(neutral_template):

--- a/tests/rules/test_EBSVolumeHasSSERule.py
+++ b/tests/rules/test_EBSVolumeHasSSERule.py
@@ -28,8 +28,8 @@ def test_failures_are_raised(bad_template):
     rule = EBSVolumeHasSSERule(Config(aws_account_id="123456789"))
     result = rule.invoke(bad_template)
 
-    assert result.valid
-    assert len(result.failed_rules) == 0
-    assert len(result.failed_monitored_rules) == 1
-    assert result.failed_monitored_rules[0].rule == "EBSVolumeHasSSERule"
-    assert result.failed_monitored_rules[0].reason == "EBS volume TestVolume should have server-side encryption enabled"
+    assert not result.valid
+    assert len(result.failed_rules) == 1
+    assert len(result.failed_monitored_rules) == 0
+    assert result.failed_rules[0].rule == "EBSVolumeHasSSERule"
+    assert result.failed_rules[0].reason == "EBS volume TestVolume should have server-side encryption enabled"

--- a/tests/rules/test_EC2SecurityGroupMissingEgressRule.py
+++ b/tests/rules/test_EC2SecurityGroupMissingEgressRule.py
@@ -26,12 +26,12 @@ def test_single_security_group_one_cidr_ingress(single_security_group_one_cidr_i
     rule = EC2SecurityGroupMissingEgressRule(None)
     result = rule.invoke(single_security_group_one_cidr_ingress)
 
-    assert result.valid
-    assert len(result.failed_rules) == 0
-    assert len(result.failed_monitored_rules) == 1
-    assert result.failed_monitored_rules[0].rule == "EC2SecurityGroupMissingEgressRule"
+    assert not result.valid
+    assert len(result.failed_rules) == 1
+    assert len(result.failed_monitored_rules) == 0
+    assert result.failed_rules[0].rule == "EC2SecurityGroupMissingEgressRule"
     assert (
-        result.failed_monitored_rules[0].reason
+        result.failed_rules[0].reason
         == "Missing egress rule in sg means all traffic is allowed outbound. Make this explicit if it is desired configuration"
     )
 
@@ -82,11 +82,11 @@ def test_non_matching_filters_are_reported_normally(single_security_group_one_ci
     processor = RuleProcessor(*rules)
     result = processor.process_cf_template(single_security_group_one_cidr_ingress, mock_config)
 
-    assert result.valid
-    assert len(result.failed_rules) == 0
-    assert len(result.failed_monitored_rules) == 1
-    assert result.failed_monitored_rules[0].rule == "EC2SecurityGroupMissingEgressRule"
+    assert not result.valid
+    assert len(result.failed_rules) == 1
+    assert len(result.failed_monitored_rules) == 0
+    assert result.failed_rules[0].rule == "EC2SecurityGroupMissingEgressRule"
     assert (
-        result.failed_monitored_rules[0].reason
+        result.failed_rules[0].reason
         == "Missing egress rule in sg means all traffic is allowed outbound. Make this explicit if it is desired configuration"
     )

--- a/tests/rules/test_GenericWildcardPrincipal.py
+++ b/tests/rules/test_GenericWildcardPrincipal.py
@@ -28,21 +28,19 @@ def test_failures_are_raised(bad_template):
     rule = GenericWildcardPrincipalRule(None)
     result = rule.invoke(bad_template)
 
-    assert result.valid
-    assert len(result.failed_rules) == 0
-    assert len(result.failed_monitored_rules) == 3
-    assert result.failed_monitored_rules[0].rule == "GenericWildcardPrincipalRule"
+    assert not result.valid
+    assert len(result.failed_rules) == 3
+    assert len(result.failed_monitored_rules) == 0
+    assert result.failed_rules[0].rule == "GenericWildcardPrincipalRule"
     assert (
-        result.failed_monitored_rules[0].reason
-        == "PolicyA should not allow wildcard in principals or account-wide principals "
+        result.failed_rules[0].reason == "PolicyA should not allow wildcard in principals or account-wide principals "
         "(principal: 'somewhatrestricted:*')"
     )
-    assert result.failed_monitored_rules[1].rule == "GenericWildcardPrincipalRule"
-    assert result.failed_monitored_rules[1].reason == "PolicyA contains an unknown principal: 123445"
-    assert result.failed_monitored_rules[2].rule == "GenericWildcardPrincipalRule"
+    assert result.failed_rules[1].rule == "GenericWildcardPrincipalRule"
+    assert result.failed_rules[1].reason == "PolicyA contains an unknown principal: 123445"
+    assert result.failed_rules[2].rule == "GenericWildcardPrincipalRule"
     assert (
-        result.failed_monitored_rules[2].reason
-        == "PolicyA should not allow wildcard in principals or account-wide principals "
+        result.failed_rules[2].reason == "PolicyA should not allow wildcard in principals or account-wide principals "
         "(principal: 'arn:aws:iam::123445:*')"
     )
 

--- a/tests/rules/test_IAMRoleWildcardActionOnPolicyRule.py
+++ b/tests/rules/test_IAMRoleWildcardActionOnPolicyRule.py
@@ -34,13 +34,12 @@ def test_valid_iam_policy_permissions(iam_role_with_wildcard_action):
     rule = IAMRoleWildcardActionOnPolicyRule(None)
     result = rule.invoke(iam_role_with_wildcard_action)
 
-    assert result.valid
-    assert len(result.failed_rules) == 0
-    assert len(result.failed_monitored_rules) == 1
-    assert result.failed_monitored_rules[0].rule == "IAMRoleWildcardActionOnPolicyRule"
+    assert not result.valid
+    assert len(result.failed_rules) == 1
+    assert len(result.failed_monitored_rules) == 0
+    assert result.failed_rules[0].rule == "IAMRoleWildcardActionOnPolicyRule"
     assert (
-        result.failed_monitored_rules[0].reason
-        == "IAM role WildcardActionRole should not allow a `*` action on its root policy"
+        result.failed_rules[0].reason == "IAM role WildcardActionRole should not allow a `*` action on its root policy"
     )
 
 
@@ -48,12 +47,12 @@ def test_valid_iam_policy_trust(iam_role_with_wildcard_action_on_trust):
     rule = IAMRoleWildcardActionOnPolicyRule(None)
     result = rule.invoke(iam_role_with_wildcard_action_on_trust)
 
-    assert result.valid
-    assert len(result.failed_rules) == 0
-    assert len(result.failed_monitored_rules) == 1
-    assert result.failed_monitored_rules[0].rule == "IAMRoleWildcardActionOnPolicyRule"
+    assert not result.valid
+    assert len(result.failed_rules) == 1
+    assert len(result.failed_monitored_rules) == 0
+    assert result.failed_rules[0].rule == "IAMRoleWildcardActionOnPolicyRule"
     assert (
-        result.failed_monitored_rules[0].reason
+        result.failed_rules[0].reason
         == "IAM role WildcardActionRole should not allow a `*` action on its AssumeRolePolicy"
     )
 
@@ -62,12 +61,12 @@ def test_invalid_managed_policy_template(iam_managed_policy_bad_template):
     rule = IAMRoleWildcardActionOnPolicyRule(Config(aws_account_id="123456789"))
     result = rule.invoke(iam_managed_policy_bad_template)
 
-    assert result.valid
-    assert len(result.failed_rules) == 0
-    assert len(result.failed_monitored_rules) == 1
-    assert result.failed_monitored_rules[0].rule == "IAMRoleWildcardActionOnPolicyRule"
+    assert not result.valid
+    assert len(result.failed_monitored_rules) == 0
+    assert len(result.failed_rules) == 1
+    assert result.failed_rules[0].rule == "IAMRoleWildcardActionOnPolicyRule"
     assert (
-        result.failed_monitored_rules[0].reason
+        result.failed_rules[0].reason
         == "IAM role CreateTestDBPolicy3 should not allow a `*` action on its AWS::IAM::ManagedPolicy"
     )
 

--- a/tests/rules/test_ManagedPolicyOnUserRule.py
+++ b/tests/rules/test_ManagedPolicyOnUserRule.py
@@ -27,11 +27,11 @@ def test_failures_are_raised(bad_template):
     rule = ManagedPolicyOnUserRule(None)
     result = rule.invoke(bad_template)
 
-    assert result.valid
-    assert len(result.failed_rules) == 0
-    assert len(result.failed_monitored_rules) == 1
-    assert result.failed_monitored_rules[0].rule == "ManagedPolicyOnUserRule"
+    assert not result.valid
+    assert len(result.failed_rules) == 1
+    assert len(result.failed_monitored_rules) == 0
+    assert result.failed_rules[0].rule == "ManagedPolicyOnUserRule"
     assert (
-        result.failed_monitored_rules[0].reason
+        result.failed_rules[0].reason
         == "IAM managed policy DirectManagedPolicy should not apply directly to users. Should be on group"
     )

--- a/tests/rules/test_PartialWildcardPrincipal.py
+++ b/tests/rules/test_PartialWildcardPrincipal.py
@@ -27,22 +27,20 @@ def test_failures_are_raised(bad_template):
     rule = PartialWildcardPrincipalRule(None)
     result = rule.invoke(bad_template)
 
-    assert result.valid
-    assert len(result.failed_rules) == 0
-    assert len(result.failed_monitored_rules) == 4
-    assert result.failed_monitored_rules[0].rule == "PartialWildcardPrincipalRule"
-    assert result.failed_monitored_rules[0].reason == "PolicyA contains an unknown principal: 123445"
-    assert result.failed_monitored_rules[1].rule == "PartialWildcardPrincipalRule"
+    assert not result.valid
+    assert len(result.failed_rules) == 4
+    assert len(result.failed_monitored_rules) == 0
+    assert result.failed_rules[0].rule == "PartialWildcardPrincipalRule"
+    assert result.failed_rules[0].reason == "PolicyA contains an unknown principal: 123445"
+    assert result.failed_rules[1].rule == "PartialWildcardPrincipalRule"
     assert (
-        result.failed_monitored_rules[1].reason
-        == "PolicyA should not allow wildcard in principals or account-wide principals "
+        result.failed_rules[1].reason == "PolicyA should not allow wildcard in principals or account-wide principals "
         "(principal: 'arn:aws:iam::123445:12345*')"
     )
-    assert result.failed_monitored_rules[2].rule == "PartialWildcardPrincipalRule"
-    assert result.failed_monitored_rules[2].reason == "PolicyA contains an unknown principal: 123445"
-    assert result.failed_monitored_rules[3].rule == "PartialWildcardPrincipalRule"
+    assert result.failed_rules[2].rule == "PartialWildcardPrincipalRule"
+    assert result.failed_rules[2].reason == "PolicyA contains an unknown principal: 123445"
+    assert result.failed_rules[3].rule == "PartialWildcardPrincipalRule"
     assert (
-        result.failed_monitored_rules[3].reason
-        == "PolicyA should not allow wildcard in principals or account-wide principals "
+        result.failed_rules[3].reason == "PolicyA should not allow wildcard in principals or account-wide principals "
         "(principal: 'arn:aws:iam::123445:root')"
     )

--- a/tests/rules/test_PolicyOnUserRule.py
+++ b/tests/rules/test_PolicyOnUserRule.py
@@ -28,11 +28,8 @@ def test_failures_are_raised(bad_template: CFModel):
     rule = PolicyOnUserRule(None)
     result = rule.invoke(bad_template)
 
-    assert result.valid
-    assert len(result.failed_rules) == 0
-    assert len(result.failed_monitored_rules) == 1
-    assert result.failed_monitored_rules[0].rule == "PolicyOnUserRule"
-    assert (
-        result.failed_monitored_rules[0].reason
-        == "IAM policy Policy should not apply directly to users. Should be on group"
-    )
+    assert not result.valid
+    assert len(result.failed_rules) == 1
+    assert len(result.failed_monitored_rules) == 0
+    assert result.failed_rules[0].rule == "PolicyOnUserRule"
+    assert result.failed_rules[0].reason == "IAM policy Policy should not apply directly to users. Should be on group"

--- a/tests/rules/test_S3BucketPublicReadAclAndListStatementRule.py
+++ b/tests/rules/test_S3BucketPublicReadAclAndListStatementRule.py
@@ -14,12 +14,12 @@ def test_s3_read_plus_list(s3_read_plus_list):
     rule = S3BucketPublicReadAclAndListStatementRule(None)
     result = rule.invoke(s3_read_plus_list)
 
-    assert result.valid
-    assert len(result.failed_rules) == 0
-    assert len(result.failed_monitored_rules) == 2
-    assert result.failed_monitored_rules[0].rule == "S3BucketPublicReadAclAndListStatementRule"
+    assert not result.valid
+    assert len(result.failed_rules) == 2
+    assert len(result.failed_monitored_rules) == 0
+    assert result.failed_rules[0].rule == "S3BucketPublicReadAclAndListStatementRule"
     assert (
-        result.failed_monitored_rules[0].reason
+        result.failed_rules[0].reason
         == "S3 Bucket S3BucketPolicy should not have a public read acl and list bucket statement"
     )
-    assert result.failed_monitored_rules[0].rule_mode == RuleMode.DEBUG
+    assert result.failed_rules[0].rule_mode == RuleMode.BLOCKING

--- a/tests/rules/test_SNSTopicPolicyNotPrincipalRule.py
+++ b/tests/rules/test_SNSTopicPolicyNotPrincipalRule.py
@@ -5,19 +5,19 @@ from tests.utils import get_cfmodel_from
 
 
 @pytest.fixture()
-def s3_bucket_with_wildcards():
+def sns_topic_not_principal():
     return get_cfmodel_from("rules/SNSTopicPolicyNotPrincipalRule/bad_template.json").resolve()
 
 
-def test_s3_bucket_with_wildcards(s3_bucket_with_wildcards):
+def test_sns_topic_not_principal(sns_topic_not_principal):
     rule = SNSTopicPolicyNotPrincipalRule(None)
-    result = rule.invoke(s3_bucket_with_wildcards)
+    result = rule.invoke(sns_topic_not_principal)
 
-    assert result.valid
-    assert len(result.failed_rules) == 0
-    assert len(result.failed_monitored_rules) == 1
-    assert result.failed_monitored_rules[0].rule == "SNSTopicPolicyNotPrincipalRule"
+    assert not result.valid
+    assert len(result.failed_rules) == 1
+    assert len(result.failed_monitored_rules) == 0
+    assert result.failed_rules[0].rule == "SNSTopicPolicyNotPrincipalRule"
     assert (
-        result.failed_monitored_rules[0].reason
+        result.failed_rules[0].reason
         == "SNS Topic mysnspolicyA policy should not allow Allow and NotPrincipal at the same time"
     )

--- a/tests/rules/test_SQSQueuePolicyNotPrincipalRule.py
+++ b/tests/rules/test_SQSQueuePolicyNotPrincipalRule.py
@@ -5,19 +5,19 @@ from tests.utils import get_cfmodel_from
 
 
 @pytest.fixture()
-def s3_bucket_with_wildcards():
+def sqs_policy_not_principal():
     return get_cfmodel_from("rules/SQSQueuePolicyNotPrincipalRule/bad_template.json").resolve()
 
 
-def test_s3_bucket_with_wildcards(s3_bucket_with_wildcards):
+def test_sqs_policy_not_principal(sqs_policy_not_principal):
     rule = SQSQueuePolicyNotPrincipalRule(None)
-    result = rule.invoke(s3_bucket_with_wildcards)
+    result = rule.invoke(sqs_policy_not_principal)
 
-    assert result.valid
-    assert len(result.failed_rules) == 0
-    assert len(result.failed_monitored_rules) == 1
-    assert result.failed_monitored_rules[0].rule == "SQSQueuePolicyNotPrincipalRule"
+    assert not result.valid
+    assert len(result.failed_monitored_rules) == 0
+    assert len(result.failed_rules) == 1
+    assert result.failed_rules[0].rule == "SQSQueuePolicyNotPrincipalRule"
     assert (
-        result.failed_monitored_rules[0].reason
+        result.failed_rules[0].reason
         == "SQS Queue QueuePolicyWithNotPrincipal policy should not allow Allow and NotPrincipal at the same time"
     )

--- a/tests/rules/test_WildcardPoliciesRule.py
+++ b/tests/rules/test_WildcardPoliciesRule.py
@@ -42,36 +42,36 @@ def test_s3_bucket_with_wildcards(s3_bucket_with_wildcards):
     rule = S3BucketPolicyWildcardActionRule(None)
     result = rule.invoke(s3_bucket_with_wildcards)
 
-    assert result.valid
-    assert len(result.failed_rules) == 0
-    assert len(result.failed_monitored_rules) == 2
-    assert result.failed_monitored_rules[0].rule == "S3BucketPolicyWildcardActionRule"
-    assert result.failed_monitored_rules[0].reason == "The S3BucketPolicy S3BucketPolicy should not allow a `*` action"
+    assert not result.valid
+    assert len(result.failed_monitored_rules) == 0
+    assert len(result.failed_rules) == 2
+    assert result.failed_rules[0].rule == "S3BucketPolicyWildcardActionRule"
+    assert result.failed_rules[0].reason == "The S3BucketPolicy S3BucketPolicy should not allow a `*` action"
 
 
 def test_sqs_queue_with_wildcards(sqs_queue_with_wildcards):
     rule = SQSQueuePolicyWildcardActionRule(None)
     result = rule.invoke(sqs_queue_with_wildcards)
 
-    assert result.valid
-    assert len(result.failed_rules) == 0
-    assert len(result.failed_monitored_rules) == 4
-    assert result.failed_monitored_rules[0].rule == "SQSQueuePolicyWildcardActionRule"
-    assert result.failed_monitored_rules[0].reason == "The SQSQueuePolicy mysqspolicy1 should not allow a `*` action"
-    assert result.failed_monitored_rules[1].rule == "SQSQueuePolicyWildcardActionRule"
-    assert result.failed_monitored_rules[1].reason == "The SQSQueuePolicy mysqspolicy1b should not allow a `*` action"
-    assert result.failed_monitored_rules[2].rule == "SQSQueuePolicyWildcardActionRule"
-    assert result.failed_monitored_rules[2].reason == "The SQSQueuePolicy mysqspolicy1c should not allow a `*` action"
-    assert result.failed_monitored_rules[3].rule == "SQSQueuePolicyWildcardActionRule"
-    assert result.failed_monitored_rules[3].reason == "The SQSQueuePolicy mysqspolicy1d should not allow a `*` action"
+    assert not result.valid
+    assert len(result.failed_monitored_rules) == 0
+    assert len(result.failed_rules) == 4
+    assert result.failed_rules[0].rule == "SQSQueuePolicyWildcardActionRule"
+    assert result.failed_rules[0].reason == "The SQSQueuePolicy mysqspolicy1 should not allow a `*` action"
+    assert result.failed_rules[1].rule == "SQSQueuePolicyWildcardActionRule"
+    assert result.failed_rules[1].reason == "The SQSQueuePolicy mysqspolicy1b should not allow a `*` action"
+    assert result.failed_rules[2].rule == "SQSQueuePolicyWildcardActionRule"
+    assert result.failed_rules[2].reason == "The SQSQueuePolicy mysqspolicy1c should not allow a `*` action"
+    assert result.failed_rules[3].rule == "SQSQueuePolicyWildcardActionRule"
+    assert result.failed_rules[3].reason == "The SQSQueuePolicy mysqspolicy1d should not allow a `*` action"
 
 
 def test_sns_topic_with_wildcards(sns_topic_with_wildcards):
     rule = SNSTopicPolicyWildcardActionRule(None)
     result = rule.invoke(sns_topic_with_wildcards)
 
-    assert result.valid
-    assert len(result.failed_rules) == 0
-    assert len(result.failed_monitored_rules) == 1
-    assert result.failed_monitored_rules[0].rule == "SNSTopicPolicyWildcardActionRule"
-    assert result.failed_monitored_rules[0].reason == "The SNSTopicPolicy mysnspolicy1 should not allow a `*` action"
+    assert not result.valid
+    assert len(result.failed_monitored_rules) == 0
+    assert len(result.failed_rules) == 1
+    assert result.failed_rules[0].rule == "SNSTopicPolicyWildcardActionRule"
+    assert result.failed_rules[0].reason == "The SNSTopicPolicy mysnspolicy1 should not allow a `*` action"


### PR DESCRIPTION
## Description

This change updates the `RULE_MODE` to `BLOCKING` for all the rules.
Now that the `rules_config` param can be passed to the `Config` class and it allows to modify the default modes of all rules easily, we can set them all to block by default so clients can update the modes of each rule to fit their preferences by using the `rules_config` param.

## Changes

- Removed the rule_mode from the rules definitions, so now all rule modes are BLOCKING which is the default
- Updated tests to reflect rule mode changes
- Fixed linting issues surfaced from updating flake8 from 3.7 to 3.8
