### PR TITLE
Modify ingress filter field to split into `ingress_obj` and `ingress_ip`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.23.0] - 2021-01-19
+### Breaking changes
+- Rule config files using filters must now use `ingress_obj` and not `ingress`.
+### Additions
+- Rules using IP Address Ranges now export both `ingress_obj` and `ingress_ip` filter fields.
+
 ## [0.22.0] - 2020-12-11
 ### Breaking changes
 - Classes inheriting from `ResourceSpecificRule` now must allow an `extra` field in the `resource_invoke` function

--- a/cfripper/__version__.py
+++ b/cfripper/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (0, 22, 0)
+VERSION = (0, 23, 0)
 
 __version__ = ".".join(map(str, VERSION))

--- a/cfripper/rules/ec2_security_group.py
+++ b/cfripper/rules/ec2_security_group.py
@@ -40,18 +40,15 @@ class SecurityGroupOpenToWorldRule(Rule, ABC):
             non_allowed_open_ports = sorted(set(open_ports) - set(self._config.allowed_world_open_ports))
 
             if non_allowed_open_ports:
+                ip_range = ingress.CidrIp or ingress.CidrIpv6
                 filters_available_context["ingress_obj"] = ingress
-                filters_available_context["ingress_ip"] = str(ingress.CidrIp or ingress.CidrIpv6)
+                filters_available_context["ingress_ip"] = str(ip_range)
                 filters_available_context["open_ports"] = open_ports
                 filters_available_context["non_allowed_open_ports"] = non_allowed_open_ports
 
                 self.add_failure_to_result(
                     result,
-                    self.REASON.format(
-                        self.get_open_ports_wording(non_allowed_open_ports),
-                        (ingress.CidrIp or ingress.CidrIpv6),
-                        logical_id,
-                    ),
+                    self.REASON.format(self.get_open_ports_wording(non_allowed_open_ports), ip_range, logical_id,),
                     resource_ids={logical_id},
                     context=filters_available_context,
                 )
@@ -142,7 +139,7 @@ class EC2SecurityGroupOpenToWorldRule(SecurityGroupOpenToWorldRule):
         |`extras`                 | str                        | `extras` variable available inside the rule                    |
         |`logical_id`             | str                        | ID used in Cloudformation to refer the resource being analysed |
         |`resource`               | `SecurityGroup`            | Resource that is being addressed                               |
-        |`ingress_ip`             | str                        | IP Address (IpV4 or IpV6) of the ingress object                |
+        |`ingress_ip`             | str                        | IP Address range (IpV4 or IpV6) of the ingress object          |
         |`ingress_obj`            | `SecurityGroupIngressProp` | SecurityGroupIngressProp being checked found in the Resource   |
         |`open_ports`             | `List[int]`                | List of all open ports defined                                 |
         |`non_allowed_open_ports` | `List[int]`                | List of all non allowed open ports defined                     |
@@ -236,7 +233,7 @@ class EC2SecurityGroupIngressOpenToWorldRule(SecurityGroupOpenToWorldRule):
         |`extras`                 | str                              | `extras` variable available inside the rule                    |
         |`logical_id`             | str                              | ID used in Cloudformation to refer the resource being analysed |
         |`resource`               | `SecurityGroupIngress`           | Resource that is being addressed                               |
-        |`ingress_ip`             | str                              | IP Address (IpV4 or IpV6) of the ingress object                |
+        |`ingress_ip`             | str                              | IP Address range (IpV4 or IpV6) of the ingress object          |
         |`ingress_obj`            | `SecurityGroupIngressProperties` | SecurityGroupIngress being checked found in the Resource       |
         |`open_ports`             | `List[int]`                      | List of all open ports defined                                 |
         |`non_allowed_open_ports` | `List[int]`                      | List of all non allowed open ports defined                     |

--- a/cfripper/rules/ec2_security_group.py
+++ b/cfripper/rules/ec2_security_group.py
@@ -40,7 +40,8 @@ class SecurityGroupOpenToWorldRule(Rule, ABC):
             non_allowed_open_ports = sorted(set(open_ports) - set(self._config.allowed_world_open_ports))
 
             if non_allowed_open_ports:
-                filters_available_context["ingress"] = ingress
+                filters_available_context["ingress_obj"] = ingress
+                filters_available_context["ingress_ip"] = str(ingress.CidrIp or ingress.CidrIpv6)
                 filters_available_context["open_ports"] = open_ports
                 filters_available_context["non_allowed_open_ports"] = non_allowed_open_ports
 
@@ -141,7 +142,8 @@ class EC2SecurityGroupOpenToWorldRule(SecurityGroupOpenToWorldRule):
         |`extras`                 | str                        | `extras` variable available inside the rule                    |
         |`logical_id`             | str                        | ID used in Cloudformation to refer the resource being analysed |
         |`resource`               | `SecurityGroup`            | Resource that is being addressed                               |
-        |`ingress`                | `SecurityGroupIngressProp` | SecurityGroupIngressProp being checked found in the Resource   |
+        |`ingress_ip`             | str                        | IP Address (IpV4 or IpV6) of the ingress object                |
+        |`ingress_obj`            | `SecurityGroupIngressProp` | SecurityGroupIngressProp being checked found in the Resource   |
         |`open_ports`             | `List[int]`                | List of all open ports defined                                 |
         |`non_allowed_open_ports` | `List[int]`                | List of all non allowed open ports defined                     |
     """
@@ -234,7 +236,8 @@ class EC2SecurityGroupIngressOpenToWorldRule(SecurityGroupOpenToWorldRule):
         |`extras`                 | str                              | `extras` variable available inside the rule                    |
         |`logical_id`             | str                              | ID used in Cloudformation to refer the resource being analysed |
         |`resource`               | `SecurityGroupIngress`           | Resource that is being addressed                               |
-        |`ingress`                | `SecurityGroupIngressProperties` | SecurityGroupIngress being checked found in the Resource       |
+        |`ingress_ip`             | str                              | IP Address (IpV4 or IpV6) of the ingress object                |
+        |`ingress_obj`            | `SecurityGroupIngressProperties` | SecurityGroupIngress being checked found in the Resource       |
         |`open_ports`             | `List[int]`                      | List of all open ports defined                                 |
         |`non_allowed_open_ports` | `List[int]`                      | List of all non allowed open ports defined                     |
     """


### PR DESCRIPTION
For rules where evaluation on the output via the use of filters is happening on `SecurityGroupIngressProperties` and `SecurityGroupIngressProp` objects, add an additional field to output just the Ipv4Network or IpV6Network string. This allows config objects containing the filters to be JSON serialisable without the need for converting between the string and network types.

**Any filters currently using `ingress`** will need to be updated to use `ingress_obj`, as shown in the updated test case:

```javascript
{"and": [{"eq": [{"ref": "config.stack_name"}, "mockstack"]}, {"eq": [{"ref": "ingress_obj.FromPort"}, 46]}]},
```

Example usage of the new filter field:

```javascript
{"in": [{"ref": "ingress_ip"}, ["11.0.0.0/8", "::/0"]]},
```