### PR TITLE
Update `ResourceSpecificRule` to allow for certain resources to be excluded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.23.2] - 2021-02-01
+### Improvements
+- Update `ResourceSpecificRule` to allow for certain resources to be excluded. In particular, the
+`PrivilegeEscalationRule` will now no longer be invoked for `S3BucketPolicy` resources.
+
 ## [0.23.1] - 2021-01-26
 ### Improvements
 - Add more X-Ray permissions that accept wildcard resource only

--- a/cfripper/__version__.py
+++ b/cfripper/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (0, 23, 1)
+VERSION = (0, 23, 2)
 
 __version__ = ".".join(map(str, VERSION))

--- a/cfripper/rules/privilege_escalation.py
+++ b/cfripper/rules/privilege_escalation.py
@@ -1,6 +1,7 @@
 __all__ = ["PrivilegeEscalationRule"]
 
 from pycfmodel.model.resources.resource import Resource
+from pycfmodel.model.resources.s3_bucket_policy import S3BucketPolicy
 
 from cfripper.model.enums import RuleGranularity
 from cfripper.rules.base_rules import BaseDangerousPolicyActions
@@ -22,6 +23,7 @@ class PrivilegeEscalationRule(BaseDangerousPolicyActions):
 
     GRANULARITY = RuleGranularity.ACTION
     REASON = "{} has blacklisted IAM actions: {}"
+    EXCLUDED_RESOURCE_TYPES = (S3BucketPolicy,)
     RESOURCE_TYPES = (Resource,)
     DANGEROUS_ACTIONS = [
         "iam:AddUserToGroup",

--- a/tests/rules/test_PrivilegeEscalationRule.py
+++ b/tests/rules/test_PrivilegeEscalationRule.py
@@ -14,6 +14,11 @@ def privilege_escalation_role_cf():
     return get_cfmodel_from("rules/PrivilegeEscalationRule/privilege_escalation_role.yaml").resolve()
 
 
+@fixture()
+def valid_privilege_escalation_on_s3_bucket_policy():
+    return get_cfmodel_from("rules/PrivilegeEscalationRule/privilege_escalation_s3_bucket_policy.yaml").resolve()
+
+
 def test_valid_role_inline_policy(valid_role_inline_policy):
     rule = PrivilegeEscalationRule(None)
     result = rule.invoke(valid_role_inline_policy)
@@ -40,3 +45,9 @@ def test_privilege_escalation_using_role(privilege_escalation_role_cf):
         result.failed_rules[0].reason
         == "PrivilegeInjectorRole has blacklisted IAM actions: ['iam:UpdateAssumeRolePolicy']"
     )
+
+
+def test_valid_privilege_escalation_on_s3_bucket_policy(valid_privilege_escalation_on_s3_bucket_policy):
+    rule = PrivilegeEscalationRule(None)
+    result = rule.invoke(valid_privilege_escalation_on_s3_bucket_policy)
+    assert result.valid

--- a/tests/test_templates/rules/PrivilegeEscalationRule/privilege_escalation_s3_bucket_policy.yaml
+++ b/tests/test_templates/rules/PrivilegeEscalationRule/privilege_escalation_s3_bucket_policy.yaml
@@ -1,0 +1,29 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: "Bucket policy with Action:* in place"
+
+Resources:
+  TestBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref SomeS3Bucket
+      PolicyDocument:
+        Version: 2008-10-17
+        Statement:
+          - Sid: Stmt123456789012
+            Effect: Allow
+            Principal:
+              {
+                CanonicalUser: 1234abcd5678,
+                AWS: "arn:aws:iam::123456789012:role/s3-bucket-foo-bar-role",
+              }
+            Action: "*"
+            Resource: "arn:aws:s3:::my-bucket-of-potatoes"
+          - Sid: Stmt987654321345
+            Effect: Allow
+            Principal:
+              {
+                CanonicalUser: 1234abcd5678,
+                AWS: "arn:aws:iam::123456789012:role/s3-bucket-foo-bar-role",
+              }
+            Action: "*"
+            Resource: "arn:aws:s3:::my-bucket-of-potatoes/*"


### PR DESCRIPTION
Some stacks were being marked as invalid by the `PrivilegeEscalation` rule as they contained dangerous IAM actions. Whilst this is true due to the use of `Action:*`, for some resources the context is not correct in which it is being applied. One example is an `S3BucketPolicy`:

```yml
TestBucketPolicy:
    Type: AWS::S3::BucketPolicy
    Properties:
      Bucket: !Ref SomeS3Bucket
      PolicyDocument:
        Version: 2008-10-17
        Statement:
          - Sid: Stmt123456789012
            Effect: Allow
            Principal:
              {
                CanonicalUser: 1234abcd5678,
                AWS: "arn:aws:iam::123456789012:role/s3-bucket-foo-bar-role",
              }
            Action: "*"
            Resource: "arn:aws:s3:::my-bucket-of-potatoes"
          - Sid: Stmt987654321345
            Effect: Allow
            Principal:
              {
                CanonicalUser: 1234abcd5678,
                AWS: "arn:aws:iam::123456789012:role/s3-bucket-foo-bar-role",
              }
            Action: "*"
            Resource: "arn:aws:s3:::my-bucket-of-potatoes/*"
```

This PR:
- adds `EXCLUDED_RESOURCE_TYPES` to the `ResourceSpecificRule`, allowing rules that inherit from this to list resources for which the rule should not be invoked on
- `PrivilegeEscalationRule` updated to exclude `S3BucketPolicy` (thus allowing the stack above to be marked as valid for this rule, which is not currently happening)

`KMSKey` resource is another good example of where we might want it excluded in some situations, but in this case it is not needed as the `BaseDangerousPolicyActions` rule only runs on `resource.policy_documents`, for which this is not supported by `KMSKey` resources yet.