### PR TITLE
Rules config filter flag to use `TextIOWrapper` and not string

### DIFF
--- a/cfripper/cli.py
+++ b/cfripper/cli.py
@@ -28,7 +28,7 @@ def setup_logging(level: str) -> None:
     logging.basicConfig(level=LOGGING_LEVELS[level], format="%(message)s")
 
 
-def init_cfripper(rules_config_file: Optional[str]) -> Tuple[Config, RuleProcessor]:
+def init_cfripper(rules_config_file: Optional[TextIOWrapper]) -> Tuple[Config, RuleProcessor]:
     config = Config(rules=DEFAULT_RULES.keys())
     if rules_config_file:
         config.load_rules_config_file(rules_config_file)
@@ -87,12 +87,12 @@ def output_handling(template_name: str, result: str, output_format: str, output_
 
 
 def process_template(
-    template,
+    template: TextIOWrapper,
     resolve: bool,
     resolve_parameters: Optional[Dict],
     output_folder: Optional[str],
     output_format: str,
-    rules_config_file: Optional[str],
+    rules_config_file: Optional[TextIOWrapper],
 ) -> bool:
     logging.info(f"Analysing {template.name}...")
 

--- a/cfripper/config/config.py
+++ b/cfripper/config/config.py
@@ -3,6 +3,7 @@ import logging
 import os
 import re
 import sys
+from io import TextIOWrapper
 from typing import Dict, List
 
 from pydantic import BaseModel
@@ -168,7 +169,9 @@ class Config:
 
         return whitelisted_rules
 
-    def load_rules_config_file(self, filename: str):
+    def load_rules_config_file(self, rules_config_file: TextIOWrapper):
+        filename = rules_config_file.name
+
         if not os.path.exists(filename):
             raise RuntimeError(f"{filename} doesn't exist")
 

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -165,7 +165,7 @@ def test_stack_to_action_whitelist_stack_without_resources(mock_rule_to_action_w
 def test_load_rules_config_file_success(test_files_location):
     mock_rules = ["RuleThatUsesResourceWhitelists", "SecurityGroupOpenToWorldRule"]
     config = Config(stack_name="test_stack", rules=mock_rules, stack_whitelist={})
-    config.load_rules_config_file(filename=f"{test_files_location}/config/rules_config_CrossAccountTrustRule.py")
+    config.load_rules_config_file(open(f"{test_files_location}/config/rules_config_CrossAccountTrustRule.py"))
     rule_config = config.get_rule_config("CrossAccountTrustRule")
     assert not rule_config.risk_value
     assert not rule_config.rule_mode
@@ -176,8 +176,8 @@ def test_load_rules_config_file_no_file(test_files_location):
     mock_rules = ["RuleThatUsesResourceWhitelists", "SecurityGroupOpenToWorldRule"]
     config = Config(stack_name="test_stack", rules=mock_rules, stack_whitelist={})
 
-    with pytest.raises(RuntimeError):
-        config.load_rules_config_file(filename=f"{test_files_location}/config/non_existing_file.py")
+    with pytest.raises(FileNotFoundError):
+        config.load_rules_config_file(open(f"{test_files_location}/config/non_existing_file.py"))
 
 
 def test_load_rules_config_file_invalid_file(test_files_location):
@@ -185,4 +185,4 @@ def test_load_rules_config_file_invalid_file(test_files_location):
     config = Config(stack_name="test_stack", rules=mock_rules, stack_whitelist={})
 
     with pytest.raises(ValidationError):
-        config.load_rules_config_file(filename=f"{test_files_location}/config/rules_config_invalid.py")
+        config.load_rules_config_file(open(f"{test_files_location}/config/rules_config_invalid.py"))

--- a/tests/rules/test_CrossAccountTrustRule.py
+++ b/tests/rules/test_CrossAccountTrustRule.py
@@ -142,7 +142,7 @@ def test_filter_works_as_expected_with_rules_config_file(
     template_two_roles_dict, expected_result_two_roles, test_files_location
 ):
     config = Config(rules=["CrossAccountTrustRule"], aws_account_id="123456789", stack_name="mockstack",)
-    config.load_rules_config_file(filename=f"{test_files_location}/config/rules_config_CrossAccountTrustRule.py")
+    config.load_rules_config_file(open(f"{test_files_location}/config/rules_config_CrossAccountTrustRule.py"))
     rules = [DEFAULT_RULES.get(rule)(config) for rule in config.rules]
     processor = RuleProcessor(*rules)
     result = processor.process_cf_template(template_two_roles_dict, config)


### PR DESCRIPTION
Running a command like this:

```bash
cfripper good_template.json --rules-config-file filter.py

Analysing tests/test_templates/rules/EC2SecurityGroupIngressOpenToWorld/good_template.json...
Unhandled exception raised, please create an issue with the error message at https://github.com/Skyscanner/cfripper/issues
Traceback (most recent call last):
  File "/Users/olivercrawford/projects/cfripper_public/cfripper/cfripper/cli.py", line 175, in cli
    for template in templates
  File "/Users/olivercrawford/projects/cfripper_public/cfripper/cfripper/cli.py", line 175, in <listcomp>
    for template in templates
  File "/Users/olivercrawford/projects/cfripper_public/cfripper/cfripper/cli.py", line 105, in process_template
    config, rule_processor = init_cfripper(rules_config_file)
  File "/Users/olivercrawford/projects/cfripper_public/cfripper/cfripper/cli.py", line 34, in init_cfripper
    config.load_rules_config_file(rules_config_file)
  File "/Users/olivercrawford/projects/cfripper_public/cfripper/cfripper/config/config.py", line 172, in load_rules_config_file
    if not os.path.exists(filename):
  File "/Users/olivercrawford/.pyenv/versions/3.7.9/lib/python3.7/genericpath.py", line 19, in exists
    os.stat(path)
TypeError: stat: path should be string, bytes, os.PathLike or integer, not _io.TextIOWrapper
```

resulted in the above error. We need to extract the name from the `TextIOWrapper` object before calling `os.path.exists(filename)`.