### PR TITLE
Update Wildcard Resource rule to allow for certain resources to be excluded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.23.3] - 2021-02-11
+### Improvements
+- Update `WildcardResourceRule` to allow for certain resources to be excluded.
+
 ## [0.23.2] - 2021-02-04
 ### Bugfix
 - `GenericWildcardPrincipalRule` to ignore account IDs where full or partial wildcard is required in the Principal.

--- a/cfripper/__version__.py
+++ b/cfripper/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (0, 23, 2)
+VERSION = (0, 23, 3)
 
 __version__ = ".".join(map(str, VERSION))

--- a/cfripper/rules/wildcard_resource_rule.py
+++ b/cfripper/rules/wildcard_resource_rule.py
@@ -2,7 +2,7 @@ __all__ = [
     "WildcardResourceRule",
 ]
 import logging
-from typing import Dict, Optional
+from typing import Dict, Optional, Tuple, Type
 
 from pycfmodel.model.cf_model import CFModel
 from pycfmodel.model.resources.generic_resource import GenericResource
@@ -41,6 +41,7 @@ class WildcardResourceRule(Rule):
         |`action`      | `Optional[str]`  | Action that has a wildcard resource. If None, means all actions |
     """
 
+    EXCLUDED_RESOURCE_TYPES: Tuple[Type] = tuple()
     REASON_WITH_POLICY_NAME = '"{}" is using a wildcard resource in "{}" for "{}"'
     REASON_WITHOUT_POLICY_NAME = '"{}" is using a wildcard resource for "{}"'
     REASON_ALL_ACTIONS_WITH_POLICY_NAME = '"{}" is using a wildcard resource in "{}" allowing all actions'
@@ -49,6 +50,8 @@ class WildcardResourceRule(Rule):
     def invoke(self, cfmodel: CFModel, extras: Optional[Dict] = None) -> Result:
         result = Result()
         for logical_id, resource in cfmodel.Resources.items():
+            if isinstance(resource, self.EXCLUDED_RESOURCE_TYPES):
+                continue
             for policy in resource.policy_documents:
                 self._check_policy_document(result, logical_id, policy.policy_document, policy.name, extras)
             if isinstance(resource, IAMRole):

--- a/tests/rules/test_WildcardResourceRule.py
+++ b/tests/rules/test_WildcardResourceRule.py
@@ -1,4 +1,5 @@
 import pytest
+from pycfmodel.model.resources.iam_policy import IAMPolicy
 
 from cfripper.model.result import Failure
 from cfripper.rules.wildcard_resource_rule import WildcardResourceRule
@@ -88,6 +89,19 @@ def test_kms_key_with_wildcard_resource_not_whitelisted_is_not_flagged(kms_key_w
     rule._config.stack_name = "stack3"
     rule.all_cf_actions = set()
     result = rule.invoke(kms_key_with_wildcard_policy)
+
+    assert result.valid
+    assert result.failed_rules == []
+    assert result.failed_monitored_rules == []
+
+
+def test_exclude_certain_resources_on_rule(iam_policy_with_wildcard_resource_and_wildcard_action):
+    # Any subclass of this rule may want to exclude certain resource types. As a test, let's exclude IAM Policies.
+    rule = WildcardResourceRule(None)
+    rule._config.stack_name = "stack3"
+    rule.all_cf_actions = set()
+    rule.EXCLUDED_RESOURCE_TYPES = (IAMPolicy,)
+    result = rule.invoke(iam_policy_with_wildcard_resource_and_wildcard_action)
 
     assert result.valid
     assert result.failed_rules == []


### PR DESCRIPTION
This rule may occasionally throw a false positive on some stacks where the Policy Document contains a `Resource: *` but the whole policy is actually being limited to a subset of AWS Resources. For example, we have SQS Queue Policies and SNS Topic Policies that are applied specifically to only some queues or topics respectively.

```yml
  SQSQueuePolicy:
    Type: 'AWS::SQS::QueuePolicy'
    Properties:
      PolicyDocument:
        Statement:
          - Sid: 'Look Dangerous; Be Nice'
            Effect: Allow
            Principal:
              AWS: '*'
            Action:
              - sqs:*
            Resource: '*'
      Queues:
        - !Ref MyAwesomeSQSQueue
```

There will be no functional changes to CFRipper from this PR - only subclasses or custom rules that use the `EXCLUDED_RESOURCE_TYPES` property will be impacted.

Change involved changing the parent class of this rule to use `ResourceSpecifcRule` and make the appropriate changes as a result of that.

A "dummy" unit test has been added.