### PR TITLE
Update boto3_client to handle known exceptions from AWS more gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [1.0.1] - 2021-03-17
+## [1.0.1] - 2021-03-25
 ### Improvements
 - Decrease logging level when loading external filters
+- Decrease logging level on known AWS errors such as AccessDenied when listing exports and
+throttling errors on getting a template from AWS CloudFormation.
 
 ## [1.0.0] - 2021-03-16
 ### Breaking changes

--- a/cfripper/__version__.py
+++ b/cfripper/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (1, 0, 0)
+VERSION = (1, 0, 1)
 
 __version__ = ".".join(map(str, VERSION))


### PR DESCRIPTION
Add exception handling around the following two events:

- receiving a `Throttling` exception when getting a template from CloudFormation (the retry mechanism is already in place along with a backoff mechanism)
- receiving a `AccessDenied` exception when listing export values (for example if the IAM role does not have permission to read these)

Unit tests updated and version + CHANGELOG bumped to 1.0.1