### PR TITLE
Downgrade logging severity from exception to warning when there is no stack in AWS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [1.0.3] - 2021-03-26
+### Improvements
+- Downgrade logging severity from exception to warning when there is no stack in AWS
+
 ## [1.0.2] - 2021-03-25
 ### Improvements
 - Handle AWS throttling errors when listing exports for a given account and region

--- a/cfripper/__version__.py
+++ b/cfripper/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (1, 0, 2)
+VERSION = (1, 0, 3)
 
 __version__ = ".".join(map(str, VERSION))

--- a/cfripper/boto3_client.py
+++ b/cfripper/boto3_client.py
@@ -50,7 +50,7 @@ class Boto3Client:
                     sleep((i + 1) * 2)
             except ClientError as e:
                 if e.response["Error"]["Code"] == "ValidationError":
-                    logger.exception(f"There is no stack: {self.stack_id} on {self.account_id} - {self.region}")
+                    logger.warning(f"There is no stack: {self.stack_id} on {self.account_id} - {self.region}")
                     return stack_content
                 elif e.response["Error"]["Code"] == "Throttling":
                     logger.warning(f"AWS Throttling: {self.stack_id} on {self.account_id} - {self.region}")

--- a/tests/test_boto3_client.py
+++ b/tests/test_boto3_client.py
@@ -45,8 +45,8 @@ def boto3_client():
             [CLIENT_ERROR_VALIDATION],
             None,
             [call("Stack: stack-id on 123456789 - eu-west-1 get_template Attempt #0")],
-            [],
             [call("There is no stack: stack-id on 123456789 - eu-west-1")],
+            [],
         ),
         (
             [CLIENT_ERROR_THROTTLING, {"A": "a"}],


### PR DESCRIPTION
This PR is a minor update to the logging severity for this use case from exception to warning as it could generate a lot of noise when running. Unit test updated and CHANGELOG and version bumped to 1.0.3