### PR TITLE
Add stack ID to output of logger when we fail to convert YML template to JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [1.0.4] - 2021-04-01
+### Improvements
+- Add `stack_id` to log output when failing to convert a YML template to JSON.
+
 ## [1.0.3] - 2021-03-26
 ### Improvements
 - Downgrade logging severity from exception to warning when there is no stack in AWS

--- a/cfripper/__version__.py
+++ b/cfripper/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (1, 0, 3)
+VERSION = (1, 0, 4)
 
 __version__ = ".".join(map(str, VERSION))

--- a/cfripper/boto3_client.py
+++ b/cfripper/boto3_client.py
@@ -64,7 +64,11 @@ class Boto3Client:
         # Fix when AWS doesn't return a dict
         # https://github.com/boto/botocore/issues/1058
         # https://github.com/boto/boto3/issues/1468
-        return convert_json_or_yaml_to_dict(stack_content) if isinstance(stack_content, str) else stack_content
+        return (
+            convert_json_or_yaml_to_dict(stack_content, self.stack_id)
+            if isinstance(stack_content, str)
+            else stack_content
+        )
 
     def download_template_to_dictionary(self, s3_url):
         """

--- a/cfripper/model/utils.py
+++ b/cfripper/model/utils.py
@@ -65,7 +65,7 @@ def extract_bucket_name_and_path_from_url(url):
     return bucket_name, path
 
 
-def convert_json_or_yaml_to_dict(file_content):
+def convert_json_or_yaml_to_dict(file_content, stack_id: Optional[str] = None):
     with suppress(ValueError):
         return json.loads(file_content)
 
@@ -74,9 +74,9 @@ def convert_json_or_yaml_to_dict(file_content):
         file_content = to_json(file_content)
         return json.loads(file_content)
     except yaml.YAMLError:
-        logger.exception("Could not convert YAML to JSON template")
+        logger.exception(f"Could not convert YAML to JSON template for {stack_id}")
     except ValueError:
-        logger.exception("Could not parse JSON template")
+        logger.exception(f"Could not parse JSON template for {stack_id}")
 
     return None
 

--- a/tests/test_boto3_client.py
+++ b/tests/test_boto3_client.py
@@ -128,6 +128,13 @@ def test_valid_yaml_as_bytes():
     assert result["hello"] == "this is valid"
 
 
+@patch("logging.Logger.exception")
+def test_invalid_yaml_as_bytes(patched_logger):
+    result = convert_json_or_yaml_to_dict(bytes("Abc: g\nh:f", "utf8"), "bad-stack")
+    assert result is None
+    patched_logger.assert_called_once_with("Could not parse JSON template for bad-stack")
+
+
 def test_valid_yaml_with_cf_shorthand_ref(s3_bucket, boto3_client):
     filename = "myexamplestack.yml"
     yaml_content = """


### PR DESCRIPTION
This PR:

- updates the logs to output the stack_id (if known) when failing to convert a template to JSON
- this will aid debugging as currently it is very difficult to track down which templates have caused issues
- added one unit test for coverage

CHANGELOG and version bumped to 1.0.4