### PR TITLE
Fix failing test_S3CrossAccountTrustRule.py::test_s3_bucket_cross_account

### DIFF
--- a/tests/test_templates/rules/S3CrossAccountTrustRule/s3_bucket_cross_account.json
+++ b/tests/test_templates/rules/S3CrossAccountTrustRule/s3_bucket_cross_account.json
@@ -83,28 +83,21 @@
         },
         "PolicyDocument": {
           "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Sid": "AllowAccessFromSandbox",
-              "Action": [
-                "s3:PutObject"
-              ],
-              "Effect": "Allow",
-              "Resource": [
-                "",
-                [
-                  "arn:aws:s3:::",
-                  "S3Bucket",
-                  "/*"
-                ]
-              ],
-              "Principal": {
-                "AWS": [
-                  "arn:aws:iam::987654321:root"
-                ]
-              }
+          "Statement": {
+            "Sid": "AllowAccessFromSandbox",
+            "Action": [
+              "s3:PutObject"
+            ],
+            "Effect": "Allow",
+            "Resource": [
+              "arn:aws:s3:::S3Bucket/*"
+            ],
+            "Principal": {
+              "AWS": [
+                "arn:aws:iam::987654321:root"
+              ]
             }
-          ]
+          }
         }
       }
     }


### PR DESCRIPTION
The root of this was quickly found by setting `GenericResource.ALLOW_EXISTING_TYPES = False`, which defaults to True in pycfmodel's GenericResource

It may be a good idea to set this to `False` for all tests so that you are using the type of object you expect.
