### PR TITLE
Catch and warn about a rule crash in S3BucketPublicReadAclAndListStatementRule

### DIFF
--- a/cfripper/rules/s3_public_access.py
+++ b/cfripper/rules/s3_public_access.py
@@ -43,8 +43,12 @@ class S3BucketPublicReadAclAndListStatementRule(Rule):
                 re.compile(r"^s3:L.*$")
             ):
                 bucket_name = resource.Properties.Bucket
+                if not isinstance(bucket_name, str):
+                    logger.warning(f"Not adding {type(self).__name__} failure in {logical_id} – try resolving?")
+                    continue
                 if "UNDEFINED_PARAM_" in bucket_name:
                     bucket_name = bucket_name[len("UNDEFINED_PARAM_") :]
+
                 bucket = cfmodel.Resources.get(bucket_name)
                 if bucket and bucket.Properties.get("AccessControl") == "PublicRead":
                     self.add_failure_to_result(


### PR DESCRIPTION
The following line in the rule from this commit is:
`bucket = cfmodel.Resources.get(bucket_name)`
It expects `bucket_name` to be a hashable object eg. string; however, for an
unresolved template at this point is will be a FunctionDict Ref at its most
basic which does not hash, and this will crash this rule.

This commit will provide a warning to the user that there may be a failure but it is not adding the rule until it is resolved, else it will crash.