### PR TITLE
Add CLI args for aws account id and aws principals

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -49,3 +49,64 @@ Analysing /tmp/root_bypass.json...
 Not adding CrossAccountTrustRule failure in rootRole because no AWS Account ID was found in the config.
 Result saved in /tmp/root_bypass.json.cfripper.results.json
 ```
+
+### Using the "aws-account-id" and "aws-principals" arguments
+
+- `--aws-account-id` is used to specify the AWS Account you want to check the template against
+- `--aws-principals` is used to specify the expected/allowed principals to ignore when checking the template 
+
+See how the output is reduced as each option is added:
+
+Without either argument, 13 issues:
+```bash
+$ cfripper ./tests/test_templates/rules/S3CrossAccountTrustRule/s3_bucket_cross_account_and_normal.json --format txt --resolve
+Analysing ./tests/test_templates/rules/S3CrossAccountTrustRule/s3_bucket_cross_account_and_normal.json...
+Using `UNDEFINED_PARAM_S3Bucket` for S3Bucket. Original value wasn't available.
+Not adding S3CrossAccountTrustRule failure in S3BucketPolicyAccountAccess because no AWS Account ID was found in the config.
+Not adding S3CrossAccountTrustRule failure in S3BucketPolicyAccountAccess because no AWS Account ID was found in the config.
+Not adding S3CrossAccountTrustRule failure in S3BucketPolicyAccountAccess because no AWS Account ID was found in the config.
+Not adding S3CrossAccountTrustRule failure in S3BucketPolicyAccountAccess because no AWS Account ID was found in the config.
+Valid: False
+Issues found:
+	- PartialWildcardPrincipalRule: S3BucketPolicyAccountAccess should not allow wildcard in principals or account-wide principals (principal: 'arn:aws:iam::123456789012:role/some-role/some-other-sub-role')
+	- PartialWildcardPrincipalRule: S3BucketPolicyAccountAccess should not allow wildcard in principals or account-wide principals (principal: 'arn:aws:iam::666555444333:root')
+	- S3BucketPolicyPrincipalRule: S3 Bucket S3BucketPolicyAccountAccess policy has non-allowed principals 123456789012
+	- S3BucketPolicyPrincipalRule: S3 Bucket S3BucketPolicyAccountAccess policy has non-allowed principals 123456789012
+	- S3BucketPolicyPrincipalRule: S3 Bucket S3BucketPolicyAccountAccess policy has non-allowed principals 123456789012
+	- S3BucketPolicyPrincipalRule: S3 Bucket S3BucketPolicyAccountAccess policy has non-allowed principals 123456789012
+	- S3BucketPolicyPrincipalRule: S3 Bucket S3BucketPolicyAccountAccess policy has non-allowed principals 123456789012
+	- S3BucketPolicyPrincipalRule: S3 Bucket S3BucketPolicyAccountAccess policy has non-allowed principals 123456789012
+	- S3BucketPolicyPrincipalRule: S3 Bucket S3BucketPolicyAccountAccess policy has non-allowed principals 123456789012
+	- S3BucketPolicyPrincipalRule: S3 Bucket S3BucketPolicyAccountAccess policy has non-allowed principals 666555444333
+	- S3BucketPolicyPrincipalRule: S3 Bucket S3BucketPolicyAccountAccess policy has non-allowed principals 123456789012
+	- S3BucketPolicyPrincipalRule: S3 Bucket S3BucketPolicyAccountAccess policy has non-allowed principals 666555444333
+	- S3BucketPublicReadAclAndListStatementRule: S3 Bucket S3BucketPolicyAccountAccess should not have a public read acl and list bucket statement
+```
+
+With `--aws-account-id` argument, 6 issues:
+```bash
+$ cfripper ./tests/test_templates/rules/S3CrossAccountTrustRule/s3_bucket_cross_account_and_normal.json --format txt --aws-account-id 123456789012 --resolve
+Analysing ./tests/test_templates/rules/S3CrossAccountTrustRule/s3_bucket_cross_account_and_normal.json...
+Using `UNDEFINED_PARAM_S3Bucket` for S3Bucket. Original value wasn't available.
+Valid: False
+Issues found:
+	- PartialWildcardPrincipalRule: S3BucketPolicyAccountAccess should not allow wildcard in principals or account-wide principals (principal: 'arn:aws:iam::123456789012:role/some-role/some-other-sub-role')
+	- PartialWildcardPrincipalRule: S3BucketPolicyAccountAccess should not allow wildcard in principals or account-wide principals (principal: 'arn:aws:iam::666555444333:root')
+	- S3BucketPolicyPrincipalRule: S3 Bucket S3BucketPolicyAccountAccess policy has non-allowed principals 666555444333
+	- S3BucketPolicyPrincipalRule: S3 Bucket S3BucketPolicyAccountAccess policy has non-allowed principals 666555444333
+	- S3BucketPublicReadAclAndListStatementRule: S3 Bucket S3BucketPolicyAccountAccess should not have a public read acl and list bucket statement
+	- S3CrossAccountTrustRule: S3BucketPolicyAccountAccess has forbidden cross-account policy allow with arn:aws:iam::666555444333:root for an S3 bucket.
+```
+
+With both arguments, 4 issues:
+```bash
+$ cfripper ./tests/test_templates/rules/S3CrossAccountTrustRule/s3_bucket_cross_account_and_normal.json --format txt --aws-account-id 123456789012 --aws-principals 666555444333 --resolve
+Analysing ./tests/test_templates/rules/S3CrossAccountTrustRule/s3_bucket_cross_account_and_normal.json...
+Using `UNDEFINED_PARAM_S3Bucket` for S3Bucket. Original value wasn't available.
+Valid: False
+Issues found:
+	- PartialWildcardPrincipalRule: S3BucketPolicyAccountAccess should not allow wildcard in principals or account-wide principals (principal: 'arn:aws:iam::123456789012:role/some-role/some-other-sub-role')
+	- PartialWildcardPrincipalRule: S3BucketPolicyAccountAccess should not allow wildcard in principals or account-wide principals (principal: 'arn:aws:iam::666555444333:root')
+	- S3BucketPublicReadAclAndListStatementRule: S3 Bucket S3BucketPolicyAccountAccess should not have a public read acl and list bucket statement
+	- S3CrossAccountTrustRule: S3BucketPolicyAccountAccess has forbidden cross-account policy allow with arn:aws:iam::666555444333:root for an S3 bucket.
+```

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -17,6 +17,8 @@ def template_two_roles_dict():
 def test_init_with_no_params():
     config = Config()
     assert config.rules is None
+    assert config.aws_account_id is None
+    assert config.aws_principals == []
 
 
 def test_init_with_nonexistent_params():
@@ -24,6 +26,16 @@ def test_init_with_nonexistent_params():
     config = Config(project_name="MISSING", service_name="MISSING", stack_name="MISSING", rules=default_rules)
 
     assert set(config.rules) == set(default_rules)
+
+
+def test_init_with_existent_params():
+    expected_aws_account_id = "123456789012"
+    expected_aws_principals = ["234567890123", "345678901234"]
+
+    config = Config(aws_account_id=expected_aws_account_id, aws_principals=expected_aws_principals)
+
+    assert config.aws_account_id == expected_aws_account_id
+    assert config.aws_principals == expected_aws_principals
 
 
 def test_load_rules_config_file_success(test_files_location):

--- a/tests/rules/test_S3CrossAccountTrustRule.py
+++ b/tests/rules/test_S3CrossAccountTrustRule.py
@@ -44,7 +44,7 @@ def test_s3_bucket_cross_account(s3_bucket_cross_account):
 
 
 def test_s3_bucket_cross_account_and_normal(s3_bucket_cross_account_and_normal):
-    rule = S3CrossAccountTrustRule(Config(aws_account_id="123456789"))
+    rule = S3CrossAccountTrustRule(Config(aws_account_id="123456789012"))
     result = rule.invoke(s3_bucket_cross_account_and_normal)
 
     assert not result.valid
@@ -53,7 +53,7 @@ def test_s3_bucket_cross_account_and_normal(s3_bucket_cross_account_and_normal):
         [
             Failure(
                 granularity=RuleGranularity.RESOURCE,
-                reason="S3BucketPolicyAccountAccess has forbidden cross-account policy allow with arn:aws:iam::666555444:root for an S3 bucket.",
+                reason="S3BucketPolicyAccountAccess has forbidden cross-account policy allow with arn:aws:iam::666555444333:root for an S3 bucket.",
                 risk_value=RuleRisk.MEDIUM,
                 rule="S3CrossAccountTrustRule",
                 rule_mode=RuleMode.BLOCKING,
@@ -65,7 +65,7 @@ def test_s3_bucket_cross_account_and_normal(s3_bucket_cross_account_and_normal):
 
 
 def test_s3_bucket_cross_account_and_normal_with_org_aws_account(s3_bucket_cross_account_and_normal):
-    rule = S3CrossAccountTrustRule(Config(aws_account_id="123456789", aws_principals=["666555444"]))
+    rule = S3CrossAccountTrustRule(Config(aws_account_id="123456789012", aws_principals=["666555444333"]))
     result = rule.invoke(s3_bucket_cross_account_and_normal)
 
     assert not result.valid
@@ -74,7 +74,7 @@ def test_s3_bucket_cross_account_and_normal_with_org_aws_account(s3_bucket_cross
         [
             Failure(
                 granularity=RuleGranularity.RESOURCE,
-                reason="S3BucketPolicyAccountAccess has forbidden cross-account policy allow with arn:aws:iam::666555444:root for an S3 bucket.",
+                reason="S3BucketPolicyAccountAccess has forbidden cross-account policy allow with arn:aws:iam::666555444333:root for an S3 bucket.",
                 risk_value=RuleRisk.MEDIUM,
                 rule="S3CrossAccountTrustRule",
                 rule_mode=RuleMode.BLOCKING,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,76 @@
+from unittest.mock import MagicMock, patch
+
+import click
+import pytest
+from click.testing import CliRunner
+
+import cfripper.cli as undertest
+from tests.utils import FIXTURE_ROOT_PATH
+
+
+@pytest.mark.parametrize(
+    "aws_account_id_arg, validation_result", [(None, None), ("", None), ("123456789012", "123456789012")],
+)
+def test_validate_aws_account_id(
+    aws_account_id_arg, validation_result,
+):
+    fake_command = click.Command("fake_command")
+    fake_context = click.Context(fake_command)
+    fake_param = "fake_param"
+    assert undertest.validate_aws_account_id(fake_context, fake_param, aws_account_id_arg) == validation_result
+
+
+def test_validate_aws_account_id_with_malformed_arg():
+    fake_command = click.Command("fake_command")
+    fake_context = click.Context(fake_command)
+    fake_param = "fake_param"
+
+    with pytest.raises(click.BadParameter):
+        undertest.validate_aws_account_id(fake_context, fake_param, "malformed aws account id")
+
+
+@pytest.mark.parametrize(
+    "aws_principals_arg, validation_result",
+    [
+        (None, None),
+        ("", None),
+        ("123456789012", ["123456789012"]),
+        (
+            "arn:aws:iam::123456789012:root,234567890123,arn:aws:iam::111222333444:user/user-name",
+            ["arn:aws:iam::123456789012:root", "234567890123", "arn:aws:iam::111222333444:user/user-name"],
+        ),
+    ],
+)
+def test_validate_aws_principals(
+    aws_principals_arg, validation_result,
+):
+    fake_command = click.Command("fake_command")
+    fake_context = click.Context(fake_command)
+    fake_param = "fake_param"
+    assert undertest.validate_aws_principals(fake_context, fake_param, aws_principals_arg) == validation_result
+
+
+@patch("cfripper.cli.process_template")
+def test_aws_account_id_cli_option(patched_process_template: MagicMock):
+    patched_process_template.return_value = True
+    test_template_path = str(FIXTURE_ROOT_PATH) + "/others/iam_role.json"
+    fake_aws_account_id = "123456789012"
+
+    runner = CliRunner()
+    result = runner.invoke(undertest.cli, ["--aws-account-id", fake_aws_account_id, test_template_path])
+    assert patched_process_template.call_count == 1
+    assert patched_process_template.call_args[1]["aws_account_id"] == fake_aws_account_id
+    assert result.exit_code == 0
+
+
+@patch("cfripper.cli.process_template")
+def test_aws_principles_cli_option(patched_process_template: MagicMock):
+    patched_process_template.return_value = True
+    test_template_path = str(FIXTURE_ROOT_PATH) + "/others/iam_role.json"
+    fake_aws_principals = ["123456789012", "234567890123"]
+
+    runner = CliRunner()
+    result = runner.invoke(undertest.cli, ["--aws-principals", ",".join(fake_aws_principals), test_template_path])
+    assert patched_process_template.call_count == 1
+    assert patched_process_template.call_args[1]["aws_principals"] == fake_aws_principals
+    assert result.exit_code == 0

--- a/tests/test_templates/rules/S3CrossAccountTrustRule/s3_bucket_cross_account_and_normal.json
+++ b/tests/test_templates/rules/S3CrossAccountTrustRule/s3_bucket_cross_account_and_normal.json
@@ -83,7 +83,7 @@
             {
               "Effect": "Allow",
               "Principal": {
-                "AWS": "arn:aws:iam::123456789:role/some-role/some-sub-role"
+                "AWS": "arn:aws:iam::123456789012:role/some-role/some-sub-role"
               },
               "Action": "s3:DeleteObjectVersion",
               "Resource": "arn:aws:s3:::company-prod-a-bucket-of-some-sort/*"
@@ -92,10 +92,10 @@
               "Effect": "Deny",
               "NotPrincipal": {
                 "AWS": [
-                  "arn:aws:sts::123456789:assumed-role/employee/employee-a",
-                  "arn:aws:iam::123456789:root",
-                  "arn:aws:sts::123456789:assumed-role/employee/employee-b",
-                  "arn:aws:iam::123456789:role/some-role/some-sub-role"
+                  "arn:aws:sts::123456789012:assumed-role/employee/employee-a",
+                  "arn:aws:iam::123456789012:root",
+                  "arn:aws:sts::123456789012:assumed-role/employee/employee-b",
+                  "arn:aws:iam::123456789012:role/some-role/some-sub-role"
                 ]
               },
               "Action": "s3:DeleteObjectVersion",
@@ -104,7 +104,7 @@
             {
               "Effect": "Allow",
               "Principal": {
-                "AWS": "arn:aws:iam::123456789:role/some-role/some-sub-role"
+                "AWS": "arn:aws:iam::123456789012:role/some-role/some-sub-role"
               },
               "Action": [
                 "s3:DeleteObject",
@@ -116,8 +116,8 @@
               "Effect": "Allow",
               "Principal": {
                 "AWS": [
-                  "arn:aws:iam::123456789:role/some-role/some-other-sub-role",
-                  "arn:aws:iam::666555444:root"
+                  "arn:aws:iam::123456789012:role/some-role/some-other-sub-role",
+                  "arn:aws:iam::666555444333:root"
                 ]
               },
               "Action": [
@@ -133,8 +133,8 @@
               "Effect": "Deny",
               "Principal": {
                 "AWS": [
-                  "arn:aws:iam::123456789:role/some-role/some-other-sub-role",
-                  "arn:aws:iam::666555444:root"
+                  "arn:aws:iam::123456789012:role/some-role/some-other-sub-role",
+                  "arn:aws:iam::666555444333:root"
                 ]
               },
               "Action": [


### PR DESCRIPTION
Whilst using CF Ripper on the command line I noticed I would get warnings such as:
`Not adding S3CrossAccountTrustRule failure in GrapplerBatchArchiveBucketPolicy because no AWS Account ID was found in the config`
And issues/errors such as:
`S3BucketPolicyPrincipalRule: S3 Bucket GrapplerBatchArchiveBucketPolicy policy has non-allowed principals <AWS Account ID>`

However, in the docs there was no way to set these from the command line. This would allow more checking locally on the CLI than having to build it into a pipeline and help find errors further to the left whilst developing.