### PR TITLE
Bump `pycfmodel` to `0.10.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [1.0.5] - 2021-06-23
+### Improvements
+- Bump `pycfmodel` to `0.10.0`. Other dependencies also updated.
+
 ## [1.0.4] - 2021-06-03
 ### Improvements
 - Add `stack_id` to log output when failing to convert a YML template to JSON.

--- a/cfripper/__version__.py
+++ b/cfripper/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (1, 0, 4)
+VERSION = (1, 0, 5)
 
 __version__ = ".".join(map(str, VERSION))

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,14 +4,13 @@
 #
 #    make freeze
 #
-boto3==1.17.86
-botocore==1.20.86
+boto3==1.17.98
+botocore==1.20.98
 cfn-flip==1.2.3
 click==7.1.2
-importlib-metadata==4.4.0
 jmespath==0.10.0
 pluggy==0.13.1
-pycfmodel==0.9.1
+pycfmodel==0.10.0
 pydantic==1.8.2
 pydash==4.7.6
 python-dateutil==2.8.1
@@ -20,4 +19,3 @@ s3transfer==0.4.2
 six==1.16.0
 typing-extensions==3.10.0.0
 urllib3==1.26.5
-zipp==3.4.1


### PR DESCRIPTION
Bump `pycfmodel` to `0.10.0`. Other dependencies also updated.