### PR TITLE
Remove default exemption for ports 80 and 443 on Open Security Group rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [1.2.0] - 2021-11-03
+### Updates
+- The rules `EC2SecurityGroupOpenToWorldRule` and `EC2SecurityGroupIngressOpenToWorldRule` were by default allowing ports 80 and 443. This has now been migrated to use a filter object, that can be optionally applied. See the README for further details. This means if the filter is not applied, Security Groups open to the world on ports 80 and 443 will start failing in CFRipper.
+
 ## [1.1.2] - 2021-10-06
 ### Fixes
 - Add a fix to the `KMSKeyEnabledKeyRotation` rule to be able to detect the `EnableKeyRotation` property properly.

--- a/cfripper/__version__.py
+++ b/cfripper/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (1, 1, 2)
+VERSION = (1, 2, 0)
 
 __version__ = ".".join(map(str, VERSION))

--- a/cfripper/config/config.py
+++ b/cfripper/config/config.py
@@ -23,7 +23,6 @@ logger = logging.getLogger(__file__)
 
 
 class Config:
-    DEFAULT_ALLOWED_WORLD_OPEN_PORTS = [80, 443]
     DEFAULT_FORBIDDEN_MANAGED_POLICY_ARNS = [
         "arn:aws:iam::aws:policy/AdministratorAccess",
         "arn:aws:iam::aws:policy/IAMFullAccess",
@@ -119,8 +118,6 @@ class Config:
             }
         else:
             self.aws_service_accounts = aws_service_accounts
-
-        self.allowed_world_open_ports = list(self.DEFAULT_ALLOWED_WORLD_OPEN_PORTS)
 
         self.forbidden_managed_policy_arns = list(self.DEFAULT_FORBIDDEN_MANAGED_POLICY_ARNS)
 

--- a/cfripper/config/rule_configs/allow_http_ports_open_to_world.py
+++ b/cfripper/config/rule_configs/allow_http_ports_open_to_world.py
@@ -1,0 +1,27 @@
+from cfripper.config.filter import Filter
+from cfripper.model.enums import RuleMode
+
+"""
+To use this Filter, or any Filter, make sure to include it in the `Config` instantiation.
+
+```python
+FILTERS = [allow_http_ports_open_to_world_rules_config_filter]
+
+config = Config(
+    ...
+    rules_filters=FILTERS,
+)
+```
+"""
+
+allow_http_ports_open_to_world_rules_config_filter = Filter(
+    reason="It can be acceptable to have Security Groups publicly available on ports 80 or 443.",
+    rule_mode=RuleMode.ALLOWED,
+    eval={
+        "and": [
+            {"exists": {"ref": "open_ports"}},
+            {"or": [{"in": [80, {"ref": "open_ports"}]}, {"in": [443, {"ref": "open_ports"}]}]},
+        ]
+    },
+    rules={"EC2SecurityGroupOpenToWorldRule", "EC2SecurityGroupIngressOpenToWorldRule"},
+)

--- a/cfripper/config/rule_configs/example_rules_config_for_cli.py
+++ b/cfripper/config/rule_configs/example_rules_config_for_cli.py
@@ -1,4 +1,7 @@
 from cfripper.config.rule_config import RuleConfig
+from cfripper.config.rule_configs.allow_http_ports_open_to_world import (
+    allow_http_ports_open_to_world_rules_config_filter,
+)
 from cfripper.config.rule_configs.firehose_ips import firehose_ips_rules_config_filter
 from cfripper.model.enums import RuleMode
 
@@ -6,4 +9,4 @@ RULES_CONFIG = {
     "EC2SecurityGroupMissingEgressRule": RuleConfig(rule_mode=RuleMode.DISABLED),
 }
 
-FILTERS = [firehose_ips_rules_config_filter]
+FILTERS = [allow_http_ports_open_to_world_rules_config_filter, firehose_ips_rules_config_filter]

--- a/cfripper/rules/ec2_security_group.py
+++ b/cfripper/rules/ec2_security_group.py
@@ -37,7 +37,7 @@ class SecurityGroupOpenToWorldRule(Rule, ABC):
     ):
         if self.non_compliant_ip_range(ingress=ingress):
             open_ports = list(range(ingress.FromPort, ingress.ToPort + 1))
-            non_allowed_open_ports = sorted(set(open_ports) - set(self._config.allowed_world_open_ports))
+            non_allowed_open_ports = sorted(set(open_ports))
 
             if non_allowed_open_ports:
                 ip_range = ingress.CidrIp or ingress.CidrIpv6

--- a/tests/rules/test_EC2SecurityGroupOpenToWorldRule.py
+++ b/tests/rules/test_EC2SecurityGroupOpenToWorldRule.py
@@ -2,6 +2,9 @@ import pytest
 
 from cfripper.config.config import Config
 from cfripper.config.filter import Filter
+from cfripper.config.rule_configs.allow_http_ports_open_to_world import (
+    allow_http_ports_open_to_world_rules_config_filter,
+)
 from cfripper.model.enums import RuleGranularity, RuleMode, RuleRisk
 from cfripper.model.result import Failure
 from cfripper.rule_processor import RuleProcessor
@@ -76,7 +79,14 @@ def test_valid_security_group_not_slash0(valid_security_group_not_slash0):
 
 
 def test_valid_security_group_port80(valid_security_group_port80):
-    rule = EC2SecurityGroupOpenToWorldRule(None)
+    rule = EC2SecurityGroupOpenToWorldRule(
+        Config(
+            rules=["EC2SecurityGroupOpenToWorldRule"],
+            aws_account_id="123456789",
+            stack_name="mockstack",
+            rules_filters=[allow_http_ports_open_to_world_rules_config_filter],
+        )
+    )
     result = rule.invoke(valid_security_group_port80)
 
     assert result.valid
@@ -84,7 +94,14 @@ def test_valid_security_group_port80(valid_security_group_port80):
 
 
 def test_valid_security_group_port443(valid_security_group_port443):
-    rule = EC2SecurityGroupOpenToWorldRule(None)
+    rule = EC2SecurityGroupOpenToWorldRule(
+        Config(
+            rules=["EC2SecurityGroupOpenToWorldRule"],
+            aws_account_id="123456789",
+            stack_name="mockstack",
+            rules_filters=[allow_http_ports_open_to_world_rules_config_filter],
+        )
+    )
     result = rule.invoke(valid_security_group_port443)
 
     assert result.valid
@@ -122,7 +139,7 @@ def test_invalid_security_group_range(invalid_security_group_range):
         [
             Failure(
                 granularity=RuleGranularity.RESOURCE,
-                reason="Port(s) 0-79, 81-100 open to public IPs: (11.0.0.0/8) in security group 'SecurityGroup'",
+                reason="Port(s) 0-100 open to public IPs: (11.0.0.0/8) in security group 'SecurityGroup'",
                 risk_value=RuleRisk.MEDIUM,
                 rule="EC2SecurityGroupOpenToWorldRule",
                 rule_mode=RuleMode.BLOCKING,
@@ -203,7 +220,7 @@ def test_non_matching_filters_are_reported_normally(invalid_security_group_range
         [
             Failure(
                 granularity=RuleGranularity.RESOURCE,
-                reason="Port(s) 0-79, 81-100 open to public IPs: (11.0.0.0/8) in security group 'SecurityGroup'",
+                reason="Port(s) 0-100 open to public IPs: (11.0.0.0/8) in security group 'SecurityGroup'",
                 risk_value=RuleRisk.MEDIUM,
                 rule="EC2SecurityGroupOpenToWorldRule",
                 rule_mode=RuleMode.BLOCKING,

--- a/tests/test_templates/rules/EC2SecurityGroupOpenToWorldRule/invalid_security_group_port78_81.json
+++ b/tests/test_templates/rules/EC2SecurityGroupOpenToWorldRule/invalid_security_group_port78_81.json
@@ -1,0 +1,19 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "SecurityGroup": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "description",
+        "SecurityGroupIngress": [
+          {
+            "IpProtocol": "tcp",
+            "CidrIp": "0.0.0.0/0",
+            "FromPort": 78,
+            "ToPort": 81
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Description

This PR removes exemptions that were being applied to the following two rules:

* EC2SecurityGroupOpenToWorldRule
* EC2SecurityGroupIngressOpenToWorldRule

If these security groups were open to ports 80 or 443, they did not fail the check. This was hardcoded configuration in CFRipper. Moving forwards, we should be using the concept of filters to make this exemption optional.

## Changes

* Remove existing hardcoded configuration around ports 80 and 443
* Create a new filter that preserves the logic of this change, but can be optionally applied (or supplemented with other conditions in the filter, depending on the use case)
* Update rules to handle the removal of the hardcoded configuration
* Update unit tests

This change will be released in version 1.2.0.