### PR TITLE
Add support for policy documents that are of type string in WildcardResourceRule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+
+# Snyk Code
+.dccache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [1.2.1] - 2021-12-24
+### Fixes
+- The `WildcardResourceRule` would fail if it received a policy document that was a string. It was expecting all policy documents to be a dictionary. Some AWS services allow for string policies though (e.g. `AWS::Logs::ResourcePolicy`). The rule has been updated to handle string policies by attempting to convert it to a dictionary.
+
 ## [1.2.0] - 2021-11-03
 ### Updates
 - The rules `EC2SecurityGroupOpenToWorldRule` and `EC2SecurityGroupIngressOpenToWorldRule` were by default allowing ports 80 and 443. This has now been migrated to use a filter object, that can be optionally applied. See the README for further details. This means if the filter is not applied, Security Groups open to the world on ports 80 and 443 will start failing in CFRipper.

--- a/cfripper/__version__.py
+++ b/cfripper/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (1, 2, 0)
+VERSION = (1, 2, 1)
 
 __version__ = ".".join(map(str, VERSION))

--- a/cfripper/rules/wildcard_resource_rule.py
+++ b/cfripper/rules/wildcard_resource_rule.py
@@ -70,8 +70,10 @@ class WildcardResourceRule(ResourceSpecificRule):
                         self._check_policy_document(
                             result, logical_id, PolicyDocument(**formatted_policy_document), None, extras
                         )
-                    except Exception as e:
-                        logger.warning(f"Could not process the PolicyDocument {policy_document} on {logical_id}: {e}.")
+                    except Exception:
+                        logger.warning(
+                            f"Could not process the PolicyDocument {policy_document} on {logical_id}", stack_info=True
+                        )
 
         return result
 

--- a/tests/rules/test_WildcardResourceRule.py
+++ b/tests/rules/test_WildcardResourceRule.py
@@ -722,7 +722,7 @@ def test_policy_with_invalid_string_policy_document(patched_logger, policy_with_
 
     assert result.valid is True
     patched_logger.assert_called_with(
-        "Could not process the PolicyDocument FOOBARFOOBAR on GuardDutyResourcePolicy: Expecting value: line 1 column 1 (char 0)."
+        "Could not process the PolicyDocument FOOBARFOOBAR on GuardDutyResourcePolicy", stack_info=True
     )
 
 

--- a/tests/rules/test_WildcardResourceRule.py
+++ b/tests/rules/test_WildcardResourceRule.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pydantic
 import pytest
 from pycfmodel.model.resources.iam_policy import IAMPolicy
@@ -41,6 +43,16 @@ def policy_with_s3_wildcard_and_all_buckets():
 @pytest.fixture()
 def user_and_policy_with_wildcard_resource():
     return get_cfmodel_from("rules/WildcardResourceRule/multiple_resources_with_wildcard_resources.json").resolve()
+
+
+@pytest.fixture()
+def policy_with_string_policy_document():
+    return get_cfmodel_from("rules/WildcardResourceRule/policy_with_string_policy_document.json").resolve()
+
+
+@pytest.fixture()
+def policy_with_invalid_string_policy_document():
+    return get_cfmodel_from("rules/WildcardResourceRule/policy_with_invalid_string_policy_document.json").resolve()
 
 
 def test_user_with_inline_policy_with_wildcard_resource_is_detected(user_with_wildcard_resource):
@@ -681,6 +693,37 @@ def test_policy_s3_wildcard_and_all_buckets(policy_with_s3_wildcard_and_all_buck
         in result.failures
     )
     assert 100 < len(result.failures)
+
+
+def test_policy_with_string_policy_document(policy_with_string_policy_document):
+    rule = WildcardResourceRule(None)
+    rule.all_cf_actions = set()
+    result = rule.invoke(policy_with_string_policy_document)
+
+    assert result.valid is False
+    assert result.failures == [
+        Failure(
+            granularity="ACTION",
+            reason='"GuardDutyResourcePolicy" is using a wildcard resource for "logs:CreateLogStream"',
+            risk_value="MEDIUM",
+            rule="WildcardResourceRule",
+            rule_mode="BLOCKING",
+            actions={"logs:CreateLogStream"},
+            resource_ids={"GuardDutyResourcePolicy"},
+        )
+    ]
+
+
+@patch("logging.Logger.warning")
+def test_policy_with_invalid_string_policy_document(patched_logger, policy_with_invalid_string_policy_document):
+    rule = WildcardResourceRule(None)
+    rule.all_cf_actions = set()
+    result = rule.invoke(policy_with_invalid_string_policy_document)
+
+    assert result.valid is True
+    patched_logger.assert_called_with(
+        "Could not process the PolicyDocument FOOBARFOOBAR on GuardDutyResourcePolicy: Expecting value: line 1 column 1 (char 0)."
+    )
 
 
 def test_policy_document_with_wildcard_resource_without_policy_name_is_detected():

--- a/tests/test_templates/rules/WildcardResourceRule/policy_with_invalid_string_policy_document.json
+++ b/tests/test_templates/rules/WildcardResourceRule/policy_with_invalid_string_policy_document.json
@@ -1,0 +1,11 @@
+{
+  "Resources": {
+    "GuardDutyResourcePolicy": {
+      "Type": "AWS::Something::Broken",
+      "Properties": {
+        "PolicyName": "something-broker",
+        "PolicyDocument": "FOOBARFOOBAR"
+      }
+    }
+  }
+}

--- a/tests/test_templates/rules/WildcardResourceRule/policy_with_invalid_string_policy_document.json
+++ b/tests/test_templates/rules/WildcardResourceRule/policy_with_invalid_string_policy_document.json
@@ -3,7 +3,7 @@
     "GuardDutyResourcePolicy": {
       "Type": "AWS::Something::Broken",
       "Properties": {
-        "PolicyName": "something-broker",
+        "PolicyName": "something-broken",
         "PolicyDocument": "FOOBARFOOBAR"
       }
     }

--- a/tests/test_templates/rules/WildcardResourceRule/policy_with_string_policy_document.json
+++ b/tests/test_templates/rules/WildcardResourceRule/policy_with_string_policy_document.json
@@ -1,0 +1,11 @@
+{
+  "Resources": {
+    "GuardDutyResourcePolicy": {
+      "Type": "AWS::Logs::ResourcePolicy",
+      "Properties": {
+        "PolicyName": "guardduty-resourcepolicy",
+        "PolicyDocument": "{\"Version\":\"2008-10-17\",\"Statement\":[{\"Sid\":\"GDAllowLogs\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"events.amazonaws.com\",\"delivery.logs.amazonaws.com\"]},\"Action\":[\"logs:CreateLogStream\"],\"Resource\":\"*\"}]}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR implements a fix for the `WildcardResourceRule` where it would fail on policy documents of type string.

Example error:

```
Traceback (most recent call last):
  File "/var/task/cfripper/rule_processor.py", line 24, in process_cf_template
    result += rule.invoke(cfmodel, extras)
  File "/var/task/cfripper/rules/base_rules.py", line 104, in invoke
    result += self.resource_invoke(resource=resource, logical_id=logical_id, extras=extras)
  File "/var/task/cfripper/rules/wildcard_resource_rule.py", line 63, in resource_invoke
    self._check_policy_document(result, logical_id, PolicyDocument(**policy_document), None, extras)
TypeError: pycfmodel.model.resources.properties.policy_document.PolicyDocument() argument after ** must be a mapping, not str
```

Unit tests added. Bumped version to 1.2.1.