### PR TITLE
Add cross account trust rule for ES and OpenSearch domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [1.3.0] - 2022-1-17
+### Improvements
+- Add `ElasticsearchDomainCrossAccountTrustRule` and `OpenSearchDomainCrossAccountTrustRule`
+- Bump `pycfmodel` to `0.13.0`
+
 ## [1.2.2] - 2022-1-07
 ### Improvements
 - Bump `pycfmodel` to `0.11.1`

--- a/cfripper/__version__.py
+++ b/cfripper/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (1, 2, 2)
+VERSION = (1, 3, 0)
 
 __version__ = ".".join(map(str, VERSION))

--- a/cfripper/rules/__init__.py
+++ b/cfripper/rules/__init__.py
@@ -4,7 +4,9 @@ from cfripper.rules.cloudformation_authentication import CloudFormationAuthentic
 from cfripper.rules.cross_account_trust import (
     CrossAccountCheckingRule,
     CrossAccountTrustRule,
+    ElasticsearchDomainCrossAccountTrustRule,
     KMSKeyCrossAccountTrustRule,
+    OpenSearchDomainCrossAccountTrustRule,
     S3CrossAccountTrustRule,
 )
 from cfripper.rules.ebs_volume_has_sse import EBSVolumeHasSSERule
@@ -51,6 +53,7 @@ DEFAULT_RULES = {
         EC2SecurityGroupIngressOpenToWorldRule,
         EC2SecurityGroupMissingEgressRule,
         EC2SecurityGroupOpenToWorldRule,
+        ElasticsearchDomainCrossAccountTrustRule,
         FullWildcardPrincipalRule,
         HardcodedRDSPasswordRule,
         IAMRolesOverprivilegedRule,
@@ -59,6 +62,7 @@ DEFAULT_RULES = {
         KMSKeyWildcardPrincipalRule,
         KMSKeyEnabledKeyRotation,
         ManagedPolicyOnUserRule,
+        OpenSearchDomainCrossAccountTrustRule,
         PartialWildcardPrincipalRule,
         PolicyOnUserRule,
         PrivilegeEscalationRule,

--- a/cfripper/rules/cross_account_trust.py
+++ b/cfripper/rules/cross_account_trust.py
@@ -1,7 +1,9 @@
 __all__ = [
     "CrossAccountCheckingRule",
     "CrossAccountTrustRule",
+    "ElasticsearchDomainCrossAccountTrustRule",
     "KMSKeyCrossAccountTrustRule",
+    "OpenSearchDomainCrossAccountTrustRule",
     "S3CrossAccountTrustRule",
 ]
 
@@ -10,8 +12,10 @@ from abc import ABC
 from typing import Dict, Optional, Set
 
 from pycfmodel.model.cf_model import CFModel
+from pycfmodel.model.resources.es_domain import ESDomain
 from pycfmodel.model.resources.iam_role import IAMRole
 from pycfmodel.model.resources.kms_key import KMSKey
+from pycfmodel.model.resources.opensearch_domain import OpenSearchDomain
 from pycfmodel.model.resources.properties.statement import Statement
 from pycfmodel.model.resources.resource import Resource
 from pycfmodel.model.resources.s3_bucket_policy import S3BucketPolicy
@@ -185,3 +189,59 @@ class KMSKeyCrossAccountTrustRule(CrossAccountCheckingRule):
     REASON = "{} has forbidden cross-account policy allow with {} for an KMS Key Policy"
     RESOURCE_TYPE = KMSKey
     PROPERTY_WITH_POLICYDOCUMENT = "KeyPolicy"
+
+
+class ElasticsearchDomainCrossAccountTrustRule(CrossAccountCheckingRule):
+    """
+    Checks for Elasticsearch domains that allow cross-account principals to get access.
+
+    Risk:
+        It might allow other AWS identities to read/modify data.
+
+    Fix:
+        If cross account permissions are required for ES domains, the stack should be added to the allowlist for this rule.
+        Otherwise, the access should be removed from the CloudFormation definition.
+
+    Filters context:
+        | Parameter   | Type        | Description                                                    |
+        |:-----------:|:-----------:|:--------------------------------------------------------------:|
+        |`config`     | str         | `config` variable available inside the rule                    |
+        |`extras`     | str         | `extras` variable available inside the rule                    |
+        |`logical_id` | str         | ID used in Cloudformation to refer the resource being analysed |
+        |`resource`   | `ESDomain`  | Resource that is being addressed                               |
+        |`statement`  | `Statement` | Statement being checked found in the Resource                  |
+        |`principal`  | `str`       | AWS Principal being checked found in the statement             |
+        |`account_id` | `str`       | Account ID found in the principal                              |
+    """
+
+    REASON = "{} has forbidden cross-account policy allow with {} for an ES domain policy."
+    RESOURCE_TYPE = ESDomain
+    PROPERTY_WITH_POLICYDOCUMENT = "AccessPolicies"
+
+
+class OpenSearchDomainCrossAccountTrustRule(CrossAccountCheckingRule):
+    """
+    Checks for OpenSearch domains that allow cross-account principals to get access.
+
+    Risk:
+        It might allow other AWS identities to read/modify data.
+
+    Fix:
+        If cross account permissions are required for OpenSearch domains, the stack should be added to the allowlist for this rule.
+        Otherwise, the access should be removed from the CloudFormation definition.
+
+    Filters context:
+        | Parameter   | Type               | Description                                                    |
+        |:-----------:|:------------------:|:--------------------------------------------------------------:|
+        |`config`     | str                | `config` variable available inside the rule                    |
+        |`extras`     | str                | `extras` variable available inside the rule                    |
+        |`logical_id` | str                | ID used in Cloudformation to refer the resource being analysed |
+        |`resource`   | `OpenSearchDomain` | Resource that is being addressed                               |
+        |`statement`  | `Statement`        | Statement being checked found in the Resource                  |
+        |`principal`  | `str`              | AWS Principal being checked found in the statement             |
+        |`account_id` | `str`              | Account ID found in the principal                              |
+    """
+
+    REASON = "{} has forbidden cross-account policy allow with {} for an OpenSearch domain policy."
+    RESOURCE_TYPE = OpenSearchDomain
+    PROPERTY_WITH_POLICYDOCUMENT = "AccessPolicies"

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ cfn-flip==1.2.3
 click==7.1.2
 jmespath==0.10.0
 pluggy==0.13.1
-pycfmodel==0.11.1
+pycfmodel==0.13.0
 pydantic==1.8.2
 pydash==4.7.6
 python-dateutil==2.8.1

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_requires = [
     "cfn_flip>=1.2.0",
     "click~=7.1.1",
     "pluggy~=0.13.1",
-    "pycfmodel>=0.11.1",
+    "pycfmodel>=0.13.0",
     "pydash~=4.7.6",
     "PyYAML>=4.2b1",
 ]

--- a/tests/test_templates/rules/CrossAccountTrustRule/es_domain_basic.yml
+++ b/tests/test_templates/rules/CrossAccountTrustRule/es_domain_basic.yml
@@ -1,0 +1,21 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Testing ES Domain
+
+Parameters:
+  Principal:
+    Type: String
+
+Resources:
+  TestDomain:
+    Type: AWS::Elasticsearch::Domain
+    Properties:
+      DomainName: "test"
+      AccessPolicies:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: "Allow full access of the domain"
+            Effect: "Allow"
+            Principal:
+              AWS: !Ref Principal
+            Action: "es:*"
+            Resource: "arn:aws:es:*:123456789012:domain/test/*"

--- a/tests/test_templates/rules/CrossAccountTrustRule/invalid_with_sts_es_domain.yml
+++ b/tests/test_templates/rules/CrossAccountTrustRule/invalid_with_sts_es_domain.yml
@@ -1,0 +1,19 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Testing ES Domain
+
+Resources:
+  TestDomain:
+    Type: AWS::Elasticsearch::Domain
+    Properties:
+      DomainName: "test"
+      AccessPolicies:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: "Allow full access of the domain"
+            Effect: "Allow"
+            Principal:
+              AWS:
+                - "arn:aws:iam::123456789:role/test-role"
+                - "arn:aws:sts::999999999:assumed-role/test-role/session"
+            Action: "es:*"
+            Resource: "arn:aws:es:*:123456789012:domain/test/*"

--- a/tests/test_templates/rules/CrossAccountTrustRule/invalid_with_sts_opensearch_domain.yml
+++ b/tests/test_templates/rules/CrossAccountTrustRule/invalid_with_sts_opensearch_domain.yml
@@ -1,0 +1,19 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Testing OpenSearch Domain
+
+Resources:
+  TestDomain:
+    Type: AWS::OpenSearchService::Domain
+    Properties:
+      DomainName: "test"
+      AccessPolicies:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: "Allow full access of the domain"
+            Effect: "Allow"
+            Principal:
+              AWS:
+                - "arn:aws:iam::123456789:role/test-role"
+                - "arn:aws:sts::999999999:assumed-role/test-role/session"
+            Action: "es:*"
+            Resource: "arn:aws:es:*:123456789012:domain/test/*"

--- a/tests/test_templates/rules/CrossAccountTrustRule/opensearch_domain_basic.yml
+++ b/tests/test_templates/rules/CrossAccountTrustRule/opensearch_domain_basic.yml
@@ -1,0 +1,21 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Testing OpenSearch Domain
+
+Parameters:
+  Principal:
+    Type: String
+
+Resources:
+  TestDomain:
+    Type: AWS::OpenSearchService::Domain
+    Properties:
+      DomainName: "test"
+      AccessPolicies:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: "Allow full access of the domain"
+            Effect: "Allow"
+            Principal:
+              AWS: !Ref Principal
+            Action: "es:*"
+            Resource: "arn:aws:es:*:123456789012:domain/test/*"

--- a/tests/test_templates/rules/CrossAccountTrustRule/valid_with_sts_es_domain.yml
+++ b/tests/test_templates/rules/CrossAccountTrustRule/valid_with_sts_es_domain.yml
@@ -1,0 +1,19 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Testing ES Domain
+
+Resources:
+  TestDomain:
+    Type: AWS::Elasticsearch::Domain
+    Properties:
+      DomainName: "test"
+      AccessPolicies:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: "Allow full access of the domain"
+            Effect: "Allow"
+            Principal:
+              AWS:
+                - "arn:aws:iam::123456789:role/test-role"
+                - "arn:aws:sts::123456789:assumed-role/test-role/session"
+            Action: "es:*"
+            Resource: "arn:aws:es:*:123456789012:domain/test/*"

--- a/tests/test_templates/rules/CrossAccountTrustRule/valid_with_sts_opensearch_domain.yml
+++ b/tests/test_templates/rules/CrossAccountTrustRule/valid_with_sts_opensearch_domain.yml
@@ -1,0 +1,19 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Testing OpenSearch Domain
+
+Resources:
+  TestDomain:
+    Type: AWS::OpenSearchService::Domain
+    Properties:
+      DomainName: "test"
+      AccessPolicies:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: "Allow full access of the domain"
+            Effect: "Allow"
+            Principal:
+              AWS:
+                - "arn:aws:iam::123456789:role/test-role"
+                - "arn:aws:sts::123456789:assumed-role/test-role/session"
+            Action: "es:*"
+            Resource: "arn:aws:es:*:123456789012:domain/test/*"


### PR DESCRIPTION
## What?
- Add `ElasticsearchDomainCrossAccountTrustRule` and `OpenSearchDomainCrossAccountTrustRule`
- Bump `pycfmodel` to `0.13.0`

Will release `1.3.0` after merging