### PR TITLE
FIX: CrossAccountCheckingRule checking resources without PROPERTY_WITH_POLICYDOCUMENT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [1.3.1] - 2022-1-17
+### Fixes
+- Fixes `CrossAccountCheckingRule` when checking resources without `PROPERTY_WITH_POLICYDOCUMENT`.
+
 ## [1.3.0] - 2022-1-17
 ### Improvements
 - Add `ElasticsearchDomainCrossAccountTrustRule` and `OpenSearchDomainCrossAccountTrustRule`

--- a/cfripper/__version__.py
+++ b/cfripper/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (1, 3, 0)
+VERSION = (1, 3, 1)
 
 __version__ = ".".join(map(str, VERSION))

--- a/cfripper/rules/cross_account_trust.py
+++ b/cfripper/rules/cross_account_trust.py
@@ -52,15 +52,16 @@ class CrossAccountCheckingRule(PrincipalCheckingRule, ABC):
             if isinstance(resource, self.RESOURCE_TYPE):
                 properties = resource.Properties
                 policy_document = getattr(properties, self.PROPERTY_WITH_POLICYDOCUMENT)
-                for statement in policy_document._statement_as_list():
-                    filters_available_context = {
-                        "config": self._config,
-                        "extras": extras,
-                        "logical_id": logical_id,
-                        "resource": resource,
-                        "statement": statement,
-                    }
-                    self._do_statement_check(result, logical_id, statement, filters_available_context)
+                if policy_document:
+                    for statement in policy_document._statement_as_list():
+                        filters_available_context = {
+                            "config": self._config,
+                            "extras": extras,
+                            "logical_id": logical_id,
+                            "resource": resource,
+                            "statement": statement,
+                        }
+                        self._do_statement_check(result, logical_id, statement, filters_available_context)
         return result
 
     def _do_statement_check(

--- a/tests/rules/test_CrossAccountTrustRule.py
+++ b/tests/rules/test_CrossAccountTrustRule.py
@@ -10,7 +10,7 @@ from cfripper.rules.cross_account_trust import (
     CrossAccountTrustRule,
     ElasticsearchDomainCrossAccountTrustRule,
     KMSKeyCrossAccountTrustRule,
-    OpenSearchDomainCrossAccountTrustRule,
+    OpenSearchDomainCrossAccountTrustRule, CrossAccountCheckingRule,
 )
 from tests.utils import compare_lists_of_failures, get_cfmodel_from
 
@@ -63,6 +63,16 @@ def template_invalid_with_sts_es_domain():
 @pytest.fixture()
 def template_invalid_with_sts_opensearch_domain():
     return get_cfmodel_from("rules/CrossAccountTrustRule/invalid_with_sts_opensearch_domain.yml").resolve()
+
+
+@pytest.fixture()
+def template_es_domain_without_access_policies():
+    return get_cfmodel_from("rules/CrossAccountTrustRule/es_domain_without_access_policies.yml").resolve()
+
+
+@pytest.fixture()
+def template_opensearch_domain_without_access_policies():
+    return get_cfmodel_from("rules/CrossAccountTrustRule/opensearch_domain_without_access_policies.yml").resolve()
 
 
 @pytest.fixture()
@@ -367,6 +377,14 @@ def test_sts_failure_es_domain(template_invalid_with_sts_es_domain):
     )
 
 
+def test_es_domain_without_access_policies(template_es_domain_without_access_policies):
+    rule = ElasticsearchDomainCrossAccountTrustRule(Config(aws_account_id="123456789", aws_principals=["999999999"]))
+    result = rule.invoke(template_es_domain_without_access_policies)
+
+    assert result.valid
+    assert compare_lists_of_failures(result.failures, [])
+
+
 @pytest.mark.parametrize(
     "principal",
     [
@@ -442,3 +460,11 @@ def test_sts_failure_opensearch_domain(template_invalid_with_sts_opensearch_doma
             )
         ],
     )
+
+
+def test_opensearch_domain_without_access_policies(template_opensearch_domain_without_access_policies):
+    rule = OpenSearchDomainCrossAccountTrustRule(Config(aws_account_id="123456789", aws_principals=["999999999"]))
+    result = rule.invoke(template_opensearch_domain_without_access_policies)
+
+    assert result.valid
+    assert compare_lists_of_failures(result.failures, [])

--- a/tests/rules/test_CrossAccountTrustRule.py
+++ b/tests/rules/test_CrossAccountTrustRule.py
@@ -10,7 +10,7 @@ from cfripper.rules.cross_account_trust import (
     CrossAccountTrustRule,
     ElasticsearchDomainCrossAccountTrustRule,
     KMSKeyCrossAccountTrustRule,
-    OpenSearchDomainCrossAccountTrustRule, CrossAccountCheckingRule,
+    OpenSearchDomainCrossAccountTrustRule,
 )
 from tests.utils import compare_lists_of_failures, get_cfmodel_from
 

--- a/tests/test_templates/rules/CrossAccountTrustRule/es_domain_without_access_policies.yml
+++ b/tests/test_templates/rules/CrossAccountTrustRule/es_domain_without_access_policies.yml
@@ -1,0 +1,12 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Testing ES Domain
+
+Parameters:
+  Principal:
+    Type: String
+
+Resources:
+  TestDomain:
+    Type: AWS::Elasticsearch::Domain
+    Properties:
+      DomainName: "test"

--- a/tests/test_templates/rules/CrossAccountTrustRule/opensearch_domain_without_access_policies.yml
+++ b/tests/test_templates/rules/CrossAccountTrustRule/opensearch_domain_without_access_policies.yml
@@ -1,0 +1,12 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Testing OpenSearchService Domain
+
+Parameters:
+  Principal:
+    Type: String
+
+Resources:
+  TestDomain:
+    Type: AWS::OpenSearchService::Domain
+    Properties:
+      DomainName: "test"


### PR DESCRIPTION
Fix rule that returned and exception when checking for ES and OpenSearch domains without AccessPolicies