### PR TITLE
Bump pycfmodel to 0.16.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [1.4.1] - 2022-2-24
+### Improvements
+- Bump `pycfmodel` to `0.16.3`
+
 ## [1.4.0] - 2022-2-21
 ### Fixes
 - Fix CI, updated tests to work with `pycfmodel` latest version which includes the use of the `Generic`.

--- a/cfripper/__version__.py
+++ b/cfripper/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (1, 4, 0)
+VERSION = (1, 4, 1)
 
 __version__ = ".".join(map(str, VERSION))

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ cfn-flip==1.3.0
 click==7.1.2
 jmespath==0.10.0
 pluggy==0.13.1
-pycfmodel==0.16.2
+pycfmodel==0.16.3
 pydantic==1.9.0
 pydash==4.7.6
 python-dateutil==2.8.2

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_requires = [
     "cfn_flip>=1.2.0",
     "click~=7.1.1",
     "pluggy~=0.13.1",
-    "pycfmodel>=0.16.2",
+    "pycfmodel>=0.16.3",
     "pydash~=4.7.6",
     "PyYAML>=4.2b1",
 ]


### PR DESCRIPTION
## [1.4.1] - 2022-2-24
### Improvements
- Bump `pycfmodel` to `0.16.3`