### PR TITLE
Fix how make install-dev works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [1.4.2] - 2022-2-24
+### Fixes
+- Fix how `make install-dev` works, it will install dependencies from `make install` first.
+### Improvements
+- Bump dev dependency `moto` from `1.3.13` to `1.3.14`.
+
 ## [1.4.1] - 2022-2-24
 ### Improvements
 - Bump `pycfmodel` to `0.16.3`

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SOURCE_ALL = $(SOURCE_DIRS) $(SOURCE_FILES)
 install:
 	pip install -r requirements.txt
 
-install-dev:
+install-dev: install
 	pip install -e ".[dev]"
 
 install-docs:

--- a/cfripper/__version__.py
+++ b/cfripper/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (1, 4, 1)
+VERSION = (1, 4, 2)
 
 __version__ = ".".join(map(str, VERSION))

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ dev_requires = [
     "pytest>=3.6",
     "pytest-cov>=2.5.1",
     "pip-tools>=5.3.1",
-    "moto==1.3.13",
+    "moto==1.3.14",
 ]
 
 docs_requires = [


### PR DESCRIPTION
## [1.4.2] - 2022-2-24
### Fixes
- Fix how `make install-dev` works, it will install dependencies from `make install` first.
### Improvements
- Bump dev dependency `moto` from `1.3.13` to `1.3.14`.