### PR TITLE
Fix EBSVolumeHasSSERule for bool type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ### Fixes
 - `EBSVolumeHasSSERule` can now understand `encrypted_status` if modelled as a `bool`.
 ### Updates
-- Updated `EBSVolumeHasSSERule` to iterate only over `AWS::EC2::Volume` resources. 
+- Updated `EBSVolumeHasSSERule` to iterate only over `AWS::EC2::Volume` resources.
 
 ## [1.7.0]
 ### Updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [1.7.1]
+### Fixes
+- `EBSVolumeHasSSERule` can now understand `encrypted_status` if modelled as a `bool`.
+### Updates
+- Updated `EBSVolumeHasSSERule` to iterate only over `AWS::EC2::Volume` resources. 
+
 ## [1.7.0]
 ### Updates
 - Added `resource_types` to failures.

--- a/cfripper/__version__.py
+++ b/cfripper/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (1, 7, 0)
+VERSION = (1, 7, 1)
 
 __version__ = ".".join(map(str, VERSION))

--- a/cfripper/rules/ebs_volume_has_sse.py
+++ b/cfripper/rules/ebs_volume_has_sse.py
@@ -50,7 +50,7 @@ class EBSVolumeHasSSERule(Rule):
         for logical_id, resource in cfmodel.resources_filtered_by_type("AWS::EC2::Volume").items():
             encrypted_status = getattr(resource.Properties, "Encrypted", None)
 
-            if encrypted_status is None or encrypted_status is False or encrypted_status.lower() != "true":
+            if encrypted_status is None or str(encrypted_status).lower() != "true":
                 self.add_failure_to_result(
                     result,
                     self.REASON.format(logical_id),

--- a/cfripper/rules/ebs_volume_has_sse.py
+++ b/cfripper/rules/ebs_volume_has_sse.py
@@ -50,7 +50,7 @@ class EBSVolumeHasSSERule(Rule):
         for logical_id, resource in cfmodel.resources_filtered_by_type("AWS::EC2::Volume").items():
             encrypted_status = getattr(resource.Properties, "Encrypted", None)
 
-            if encrypted_status is None or str(encrypted_status).lower() != "true":
+            if encrypted_status is None or encrypted_status is False:
                 self.add_failure_to_result(
                     result,
                     self.REASON.format(logical_id),

--- a/cfripper/rules/ebs_volume_has_sse.py
+++ b/cfripper/rules/ebs_volume_has_sse.py
@@ -47,21 +47,15 @@ class EBSVolumeHasSSERule(Rule):
 
     def invoke(self, cfmodel: CFModel, extras: Optional[Dict] = None) -> Result:
         result = Result()
-        for logical_id, resource in cfmodel.Resources.items():
-            if resource.Type == "AWS::EC2::Volume":
-                encrypted_status = getattr(resource.Properties, "Encrypted", None)
+        for logical_id, resource in cfmodel.resources_filtered_by_type("AWS::EC2::Volume").items():
+            encrypted_status = getattr(resource.Properties, "Encrypted", None)
 
-                if encrypted_status is None or encrypted_status.lower() != "true":
-                    self.add_failure_to_result(
-                        result,
-                        self.REASON.format(logical_id),
-                        resource_ids={logical_id},
-                        resource_types={resource.Type},
-                        context={
-                            "config": self._config,
-                            "extras": extras,
-                            "logical_id": logical_id,
-                            "resource": resource,
-                        },
-                    )
+            if encrypted_status is None or encrypted_status is False or encrypted_status.lower() != "true":
+                self.add_failure_to_result(
+                    result,
+                    self.REASON.format(logical_id),
+                    resource_ids={logical_id},
+                    resource_types={resource.Type},
+                    context={"config": self._config, "extras": extras, "logical_id": logical_id, "resource": resource},
+                )
         return result

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,18 +4,18 @@
 #
 #    make freeze
 #
-boto3==1.21.2
-botocore==1.24.2
+boto3==1.21.31
+botocore==1.24.31
 cfn-flip==1.3.0
 click==7.1.2
-jmespath==0.10.0
+jmespath==1.0.0
 pluggy==0.13.1
-pycfmodel==0.17.0
+pycfmodel==0.18.0
 pydantic==1.9.0
 pydash==4.7.6
 python-dateutil==2.8.2
 pyyaml==6.0
-s3transfer==0.5.1
+s3transfer==0.5.2
 six==1.16.0
 typing-extensions==4.1.1
-urllib3==1.26.8
+urllib3==1.26.9

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_requires = [
     "cfn_flip>=1.2.0",
     "click~=7.1.1",
     "pluggy~=0.13.1",
-    "pycfmodel>=0.17.0",
+    "pycfmodel>=0.18.0",
     "pydash~=4.7.6",
     "PyYAML>=4.2b1",
 ]

--- a/tests/rules/test_EBSVolumeHasSSERule.py
+++ b/tests/rules/test_EBSVolumeHasSSERule.py
@@ -25,9 +25,12 @@ def test_no_failures_are_raised(good_template):
     assert compare_lists_of_failures(result.failures, [])
 
 
-def test_failures_are_raised(bad_template):
+@pytest.mark.parametrize(
+    "template_path", ["rules/EBSVolumeHasSSERule/bad_template.json", "rules/EBSVolumeHasSSERule/bad_template.yaml"],
+)
+def test_failures_are_raised(template_path):
     rule = EBSVolumeHasSSERule(Config(aws_account_id="123456789"))
-    result = rule.invoke(bad_template)
+    result = rule.invoke(get_cfmodel_from(template_path).resolve())
 
     assert not result.valid
     assert compare_lists_of_failures(

--- a/tests/test_templates/rules/EBSVolumeHasSSERule/bad_template.yaml
+++ b/tests/test_templates/rules/EBSVolumeHasSSERule/bad_template.yaml
@@ -1,0 +1,9 @@
+Resources:
+  TestVolume:
+    Type: AWS::EC2::Volume
+    Properties:
+      Size: 99
+      Encrypted: False
+      Tags:
+        - Key: MyTag
+          Value: TagValue


### PR DESCRIPTION
## [1.7.1]
### Fixes
- `EBSVolumeHasSSERule` can now understand `encrypted_status` if modelled as a `bool`.
### Updates
- Updated `EBSVolumeHasSSERule` to iterate only over `AWS::EC2::Volume` resources.