### PR TITLE
Bump pycfmodel to allow resources without properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [1.8.1]
+### Improvements
+- Bump `pycfmodel` to `0.18.1`.
+
 ## [1.8.0]
 ### Improvements
 - Pin `click` to at least version `8.0.0`.

--- a/cfripper/__version__.py
+++ b/cfripper/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (1, 8, 0)
+VERSION = (1, 8, 1)
 
 __version__ = ".".join(map(str, VERSION))

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ cfn-flip==1.3.0
 click==8.1.2
 jmespath==1.0.0
 pluggy==0.13.1
-pycfmodel==0.18.0
+pycfmodel==0.18.1
 pydantic==1.9.0
 pydash==4.7.6
 python-dateutil==2.8.2

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_requires = [
     "cfn_flip>=1.2.0",
     "click>=8.0.0",
     "pluggy~=0.13.1",
-    "pycfmodel>=0.18.0",
+    "pycfmodel>=0.18.1",
     "pydash~=4.7.6",
     "PyYAML>=4.2b1",
 ]


### PR DESCRIPTION
## [1.8.1]
### Improvements
- Bump `pycfmodel` to `0.18.1`.