### PR TITLE
default logging level from INFO to WARNING

### DIFF
--- a/cfripper/cli.py
+++ b/cfripper/cli.py
@@ -179,7 +179,7 @@ def validate_aws_principals(ctx: click.Context, param: str, value: str) -> Optio
     "--logging",
     "logging_level",
     type=click.Choice(LOGGING_LEVELS.keys(), case_sensitive=True),
-    default="INFO",
+    default="WARNING",
     help="Logging level",
     show_default=True,
 )


### PR DESCRIPTION
https://sourcegraph.com/search?q=r:Skyscanner/cfripper+.info

[`WildcardResourceRule`](https://cfripper.readthedocs.io/en/latest/rules/#wildcardresourcerule) in particular can generate a lot of non-actionable noise:
https://github.com/Skyscanner/cfripper/blob/3c7b068db6bf130f113a5ba9271100c6292d14e2/cfripper/rules/wildcard_resource_rule.py#L134-L140