### PR TITLE
Fix rds_security_group.py docs

### DIFF
--- a/cfripper/rules/rds_security_group.py
+++ b/cfripper/rules/rds_security_group.py
@@ -28,7 +28,7 @@ class RDSSecurityGroupIngressOpenToWorldRule(ResourceSpecificRule):
 
     Code example:
 
-        ````yaml
+        ```yaml
         Resources:
           CompliantRDSSecurityGroup:
             Type: AWS::RDS::DBSecurityGroup
@@ -44,7 +44,7 @@ class RDSSecurityGroupIngressOpenToWorldRule(ResourceSpecificRule):
               DBSecurityGroupIngress:
                 - CIDRIP: 0.0.0.0/0
               GroupDescription: Risky RDS security group
-    ````
+        ```
 
     Filters context:
         | Parameter               | Type                                           | Description                                                    |


### PR DESCRIPTION
Docs are broken, see: https://cfripper.readthedocs.io/en/latest/rules/#rdssecuritygroupingressopentoworldrule
