### PR TITLE
Create stack name example rule

### DIFF
--- a/cfripper/config/regex.py
+++ b/cfripper/config/regex.py
@@ -173,3 +173,18 @@ Invalid:
 - sns:Get*
 """
 REGEX_HAS_STAR_OR_STAR_AFTER_COLON = re.compile(r"^(\w*:)*[*?]+$")
+
+
+"""
+Check that stack name only consists of alphanumerical characters and hyphens.
+Valid:
+- abcdefg
+- ABCDEFG
+- abcdEFG
+- aBc-DeFG
+Invalid:
+- abc_defg
+- AB:cdefg
+- !@£$$%aA
+"""
+REGEX_ALPHANUMERICAL_OR_HYPHEN = re.compile(r"^[A-Za-z0-9\-]+$")

--- a/cfripper/config/regex.py
+++ b/cfripper/config/regex.py
@@ -182,6 +182,7 @@ Valid:
 - ABCDEFG
 - abcdEFG
 - aBc-DeFG
+- a1b2c3
 Invalid:
 - abc_defg
 - AB:cdefg

--- a/cfripper/rules/__init__.py
+++ b/cfripper/rules/__init__.py
@@ -38,6 +38,7 @@ from cfripper.rules.sqs_queue_policy import (
     SQSQueuePolicyNotPrincipalRule,
     SQSQueuePolicyPublicRule,
 )
+from cfripper.rules.stack_name_matches_regex import StackNameMatchesRegexRule
 from cfripper.rules.wildcard_policies import (
     GenericResourceWildcardPolicyRule,
     S3BucketPolicyWildcardActionRule,
@@ -94,6 +95,7 @@ DEFAULT_RULES = {
         SQSQueuePolicyNotPrincipalRule,
         SQSQueuePolicyPublicRule,
         SQSQueuePolicyWildcardActionRule,
+        StackNameMatchesRegexRule,
         WildcardResourceRule,
     )
 }

--- a/cfripper/rules/stack_name_matches_regex.py
+++ b/cfripper/rules/stack_name_matches_regex.py
@@ -1,4 +1,3 @@
-import re
 from typing import Dict, Optional
 
 from pycfmodel.model.cf_model import CFModel

--- a/cfripper/rules/stack_name_matches_regex.py
+++ b/cfripper/rules/stack_name_matches_regex.py
@@ -1,0 +1,41 @@
+import re
+from typing import Dict, Optional
+
+from pycfmodel.model.cf_model import CFModel
+
+from cfripper.config.regex import REGEX_ALPHANUMERICAL_OR_HYPHEN
+from cfripper.model.enums import RuleMode, RuleRisk
+from cfripper.model.result import Result
+from cfripper.rules.base_rules import Rule
+
+
+class StackNameMatchesRegexRule(Rule):
+    """
+    Checks that a given stack follows the naming convention given by a regex.
+    """
+
+    RULE_MODE = RuleMode.DEBUG
+    RISK_VALUE = RuleRisk.LOW
+    REASON = (
+        "The stack name {} does not follow the naming convention (only alphanumerical characters and hyphens allowed)."
+    )
+
+    def _stack_name_matches_regex(self, stack_name: str) -> bool:
+        """Check that stack name follows naming convention."""
+        return bool(REGEX_ALPHANUMERICAL_OR_HYPHEN.match(stack_name))
+
+    def invoke(self, cfmodel: CFModel, extras: Optional[Dict] = None) -> Result:
+        result = Result()
+        stack_name = self._config.stack_name
+        if not stack_name:
+            return result
+        if not extras:
+            extras = {}
+
+        if not self._stack_name_matches_regex(stack_name):
+            self.add_failure_to_result(
+                result,
+                self.REASON.format(stack_name),
+                context={"config": self._config, "extras": extras},
+            )
+        return result

--- a/cfripper/rules/stack_name_matches_regex.py
+++ b/cfripper/rules/stack_name_matches_regex.py
@@ -3,29 +3,33 @@ from typing import Dict, Optional
 from pycfmodel.model.cf_model import CFModel
 
 from cfripper.config.regex import REGEX_ALPHANUMERICAL_OR_HYPHEN
-from cfripper.model.enums import RuleMode, RuleRisk
+from cfripper.model.enums import RuleGranularity, RuleMode, RuleRisk
 from cfripper.model.result import Result
 from cfripper.rules.base_rules import Rule
 
 
 class StackNameMatchesRegexRule(Rule):
     """
-    Checks that a given stack follows the naming convention given by a regex.
+    Checks that a given stack follows the naming convention given by a regex. For this to work,
+    the stack name must be given either in the config or in the extras using the key
+    "stack_name".
     """
 
-    RULE_MODE = RuleMode.DEBUG
+    RULE_MODE = RuleMode.DEBUG  # for demonstration purposes
     RISK_VALUE = RuleRisk.LOW
+    GRANULARITY = RuleGranularity.STACK
     REASON = (
         "The stack name {} does not follow the naming convention (only alphanumerical characters and hyphens allowed)."
     )
+    REGEX = REGEX_ALPHANUMERICAL_OR_HYPHEN
 
     def _stack_name_matches_regex(self, stack_name: str) -> bool:
         """Check that stack name follows naming convention."""
-        return bool(REGEX_ALPHANUMERICAL_OR_HYPHEN.match(stack_name))
+        return bool(self.REGEX.match(stack_name))
 
     def invoke(self, cfmodel: CFModel, extras: Optional[Dict] = None) -> Result:
         result = Result()
-        stack_name = self._config.stack_name
+        stack_name = self._config.stack_name or extras.get("stack_name", "")
         if not stack_name:
             return result
         if not extras:
@@ -35,6 +39,8 @@ class StackNameMatchesRegexRule(Rule):
             self.add_failure_to_result(
                 result,
                 self.REASON.format(stack_name),
+                self.GRANULARITY,
+                risk_value=self.RISK_VALUE,
                 context={"config": self._config, "extras": extras},
             )
         return result

--- a/cfripper/rules/stack_name_matches_regex.py
+++ b/cfripper/rules/stack_name_matches_regex.py
@@ -18,10 +18,9 @@ class StackNameMatchesRegexRule(Rule):
     RULE_MODE = RuleMode.DEBUG  # for demonstration purposes
     RISK_VALUE = RuleRisk.LOW
     GRANULARITY = RuleGranularity.STACK
-    REASON = (
-        "The stack name {} does not follow the naming convention (only alphanumerical characters and hyphens allowed)."
-    )
+    REASON = "The stack name {} does not follow the naming convention, reason: {}"
     REGEX = REGEX_ALPHANUMERICAL_OR_HYPHEN
+    REGEX_REASON = "Only alphanumerical characters and hyphens allowed."
 
     def _stack_name_matches_regex(self, stack_name: str) -> bool:
         """Check that stack name follows naming convention."""
@@ -38,7 +37,7 @@ class StackNameMatchesRegexRule(Rule):
         if not self._stack_name_matches_regex(stack_name):
             self.add_failure_to_result(
                 result,
-                self.REASON.format(stack_name),
+                self.REASON.format(stack_name, self.REGEX_REASON),
                 self.GRANULARITY,
                 risk_value=self.RISK_VALUE,
                 context={"config": self._config, "extras": extras},

--- a/tests/rules/test_StackNameMatchesRegexRule.py
+++ b/tests/rules/test_StackNameMatchesRegexRule.py
@@ -1,0 +1,39 @@
+import pytest
+from pycfmodel.model.cf_model import CFModel
+
+from cfripper.config.config import Config
+from cfripper.rules import StackNameMatchesRegexRule
+
+
+@pytest.mark.parametrize(
+    "stack_name, expected_result",
+    [
+        ("justlowercase", True),
+        ("lowercase-with-hyphens", True),
+        ("lowercaseANDUPPERCASE", True),
+        ("lowercase-AND-UPPERCASE-with-hyphens", True),
+        ("including_underscore", False),
+        ("including space", False),
+        ("including-other-symbols!@£$%^&*()", False),
+    ],
+)
+def test_stack_name_matches_regex(stack_name, expected_result):
+    rule = StackNameMatchesRegexRule(Config(stack_name=stack_name, rules=["StackNameMatchesRegexRule"]))
+    assert rule._stack_name_matches_regex(stack_name) == expected_result
+
+
+def test_works_with_extras():
+    rule = StackNameMatchesRegexRule(Config(stack_name="some-valid-stack-name", rules=["StackNameMatchesRegexRule"]))
+    extras = {"stack": {"tags": [{"key": "project", "value": "some_project"}]}}
+    result = rule.invoke(cfmodel=CFModel(), extras=extras)
+    assert result.valid
+
+
+def test_failure_is_added_for_invalid_stack_name():
+    rule = StackNameMatchesRegexRule(Config(stack_name="some_invalid_stack_name", rules=["StackNameMatchesRegexRule"]))
+    result = rule.invoke(cfmodel=CFModel())
+    assert result.failures
+    assert (
+        result.failures[0].reason
+        == "The stack name some_invalid_stack_name does not follow the naming convention (only alphanumerical characters and hyphens allowed)."
+    )

--- a/tests/rules/test_StackNameMatchesRegexRule.py
+++ b/tests/rules/test_StackNameMatchesRegexRule.py
@@ -29,6 +29,7 @@ def test_works_with_extras():
     result = rule.invoke(cfmodel=CFModel(), extras=extras)
     assert result.valid
 
+
 def test_stack_name_from_extras():
     rule = StackNameMatchesRegexRule(Config(stack_name="some-valid-stack-name", rules=["StackNameMatchesRegexRule"]))
     extras = {"stack": {"tags": [{"key": "project", "value": "some_project"}]}, "stack_name": "some_invalid_name"}
@@ -42,15 +43,18 @@ def test_failure_is_added_for_invalid_stack_name():
     assert result.failures
     assert (
         result.failures[0].reason
-        == "The stack name some_invalid_stack_name does not follow the naming convention (only alphanumerical characters and hyphens allowed)."
+        == "The stack name some_invalid_stack_name does not follow the naming convention (only alphanumerical "
+        "characters and hyphens allowed)."
     )
 
-def failure_is_added_for_invalid_stack_name_from_extras():
+
+def test_failure_is_added_for_invalid_stack_name_from_extras():
     rule = StackNameMatchesRegexRule(Config(rules=["StackNameMatchesRegexRule"]))
     extras = {"stack": {"tags": [{"key": "project", "value": "some_project"}]}, "stack_name": "some_invalid_stack_name"}
     result = rule.invoke(cfmodel=CFModel(), extras=extras)
     assert result.failures
     assert (
-            result.failures[0].reason
-            == "The stack name some_invalid_stack_name does not follow the naming convention (only alphanumerical characters and hyphens allowed)."
+        result.failures[0].reason
+        == "The stack name some_invalid_stack_name does not follow the naming convention (only alphanumerical "
+        "characters and hyphens allowed)."
     )

--- a/tests/rules/test_StackNameMatchesRegexRule.py
+++ b/tests/rules/test_StackNameMatchesRegexRule.py
@@ -12,6 +12,7 @@ from cfripper.rules import StackNameMatchesRegexRule
         ("lowercase-with-hyphens", True),
         ("lowercaseANDUPPERCASE", True),
         ("lowercase-AND-UPPERCASE-with-hyphens", True),
+        ("also-123-including-456-numbers", True),
         ("including_underscore", False),
         ("including space", False),
         ("including-other-symbols!@£$%^&*()", False),
@@ -28,6 +29,12 @@ def test_works_with_extras():
     result = rule.invoke(cfmodel=CFModel(), extras=extras)
     assert result.valid
 
+def test_stack_name_from_extras():
+    rule = StackNameMatchesRegexRule(Config(stack_name="some-valid-stack-name", rules=["StackNameMatchesRegexRule"]))
+    extras = {"stack": {"tags": [{"key": "project", "value": "some_project"}]}, "stack_name": "some_invalid_name"}
+    result = rule.invoke(cfmodel=CFModel(), extras=extras)
+    assert result.valid
+
 
 def test_failure_is_added_for_invalid_stack_name():
     rule = StackNameMatchesRegexRule(Config(stack_name="some_invalid_stack_name", rules=["StackNameMatchesRegexRule"]))
@@ -36,4 +43,14 @@ def test_failure_is_added_for_invalid_stack_name():
     assert (
         result.failures[0].reason
         == "The stack name some_invalid_stack_name does not follow the naming convention (only alphanumerical characters and hyphens allowed)."
+    )
+
+def failure_is_added_for_invalid_stack_name_from_extras():
+    rule = StackNameMatchesRegexRule(Config(rules=["StackNameMatchesRegexRule"]))
+    extras = {"stack": {"tags": [{"key": "project", "value": "some_project"}]}, "stack_name": "some_invalid_stack_name"}
+    result = rule.invoke(cfmodel=CFModel(), extras=extras)
+    assert result.failures
+    assert (
+            result.failures[0].reason
+            == "The stack name some_invalid_stack_name does not follow the naming convention (only alphanumerical characters and hyphens allowed)."
     )

--- a/tests/rules/test_StackNameMatchesRegexRule.py
+++ b/tests/rules/test_StackNameMatchesRegexRule.py
@@ -43,8 +43,8 @@ def test_failure_is_added_for_invalid_stack_name():
     assert result.failures
     assert (
         result.failures[0].reason
-        == "The stack name some_invalid_stack_name does not follow the naming convention (only alphanumerical "
-        "characters and hyphens allowed)."
+        == "The stack name some_invalid_stack_name does not follow the naming convention, reason: Only alphanumerical "
+        "characters and hyphens allowed."
     )
 
 
@@ -55,6 +55,6 @@ def test_failure_is_added_for_invalid_stack_name_from_extras():
     assert result.failures
     assert (
         result.failures[0].reason
-        == "The stack name some_invalid_stack_name does not follow the naming convention (only alphanumerical "
-        "characters and hyphens allowed)."
+        == "The stack name some_invalid_stack_name does not follow the naming convention, reason: Only alphanumerical "
+        "characters and hyphens allowed."
     )


### PR DESCRIPTION
We add a new rule that checks whether the stack name only consists of alphanumerical characters and hyphens.