### PR TITLE
Fix logo in pypi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-<img src="docs/img/logo.png" width="200" alt="cfripper logo">
+<img src="https://raw.githubusercontent.com/Skyscanner/cfripper/master/docs/img/logo.png" width="200" alt="cfripper logo">
 </p>
 
 # CFRipper


### PR DESCRIPTION
Logo is broken in https://pypi.org/project/cfripper/
According to https://github.com/pypi/warehouse/issues/5246 using the url fixes it.
Readme is still looking good https://github.com/Skyscanner/cfripper/tree/fix_pypi_logo
