### PR TITLE
Removed user and password from pypi-release.yml

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -35,6 +35,3 @@ jobs:
 
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
I'm creating this PR because we're introducing GitHub Actions as a trusted publisher to the cfripper library. Here, we're making an update to the pypi-release workflow so we remove the username and password as this is not needed.
