### PR TITLE
add the upload endpoint for PyPi 

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -35,3 +35,5 @@ jobs:
 
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://upload.pypi.org/legacy/


### PR DESCRIPTION
I'm creating this PR because, as part of introducing GitHub Actions as a trusted publisher, we need to add the upload endpoint of PyPi to the pypi-release.yml workflow. That is what I do in this PR.
