### PR TITLE
Resolve datetime deprecation warnings

### DIFF
--- a/cfripper/boto3_client.py
+++ b/cfripper/boto3_client.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from time import sleep
 from typing import Dict, Optional
 
@@ -22,7 +22,7 @@ class Boto3Client:
         logger.info(f"Preparing to assume role: {arn}")
 
         client = boto3.client("sts")
-        now = datetime.utcnow().isoformat().replace(":", ".")
+        now = datetime.now(timezone.utc).replace(tzinfo=None).isoformat().replace(":", ".")
         role_session_name = f"CfRipper{now}{stack_id.replace(':', '.')}"[:64]  # Limit of 64 chars
         response = client.assume_role(RoleArn=arn, RoleSessionName=role_session_name)
         self.session = boto3.Session(


### PR DESCRIPTION
# Description
This small PR resolves the `datetime` deprecation warnings which you can see in the [CI logs](https://github.com/Skyscanner/cfripper/actions/runs/14666499624/job/41162481548#step:6:1770):
```python
/home/runner/work/cfripper/cfripper/cfripper/boto3_client.py:25: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    now = datetime.utcnow().isoformat().replace(":", ".")
```

## Checklist

- [ ] I have updated the CHANGELOG.md file accordingly
