### PR TITLE
Truncate reason in metrics logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [1.18.1]
+### Updates
+- Truncate metric arguments to 4000 characters
+
 ## [1.18.0]
 ### Updates
 - Add support for repo_name in config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,14 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [1.18.1]
+## [1.17.2]
 ### Updates
 - Truncate metric arguments to 4000 characters
-
-## [1.18.0]
-### Updates
-- Add support for repo_name in config
 
 ## [1.17.1]
 ### Updates
 - Solve low-severity warnings for better readability
+- Add support for repo_name in config
 
 ## [1.17.0]
 ### Additions

--- a/cfripper/cloudformation_actions_only_accepts_wildcard.py
+++ b/cfripper/cloudformation_actions_only_accepts_wildcard.py
@@ -1,5 +1,5 @@
 CLOUDFORMATION_ACTIONS_ONLY_ACCEPTS_WILDCARD = [
-    'acm:RequestCertificate',
+    "acm:RequestCertificate",
     "batch:CancelJob",
     "batch:DescribeComputeEnvironments",
     "batch:DescribeJobDefinitions",

--- a/cfripper/rules/base_rules.py
+++ b/cfripper/rules/base_rules.py
@@ -64,7 +64,9 @@ class Rule(ABC):
                     risk_value = rule_filter.risk_value or risk_value
                     rule_mode = rule_filter.rule_mode or rule_mode
                     if self._config.metrics_logger:
-                        self._config.metrics_logger(rule=self.__class__.__name__, filter_reason=rule_filter.reason)
+                        self._config.metrics_logger(
+                            rule=self.__class__.__name__, filter_reason=rule_filter.reason[:4000]
+                        )
             except Exception:
                 logger.exception(
                     f"Exception raised while evaluating rule {self.__class__.__name__} "

--- a/cfripper/rules/base_rules.py
+++ b/cfripper/rules/base_rules.py
@@ -19,6 +19,8 @@ class Rule(ABC):
     RISK_VALUE = RuleRisk.MEDIUM
     GRANULARITY = RuleGranularity.STACK
 
+    MAX_METRIC_ARG_LENGTH = 4000
+
     def __init__(self, config: Optional[Config]):
         self._config = config if config else Config()
 
@@ -65,7 +67,8 @@ class Rule(ABC):
                     rule_mode = rule_filter.rule_mode or rule_mode
                     if self._config.metrics_logger:
                         self._config.metrics_logger(
-                            rule=self.__class__.__name__[:4000], filter_reason=rule_filter.reason[:4000]
+                            rule=self.__class__.__name__[: self.MAX_METRIC_ARG_LENGTH],
+                            filter_reason=rule_filter.reason[: self.MAX_METRIC_ARG_LENGTH],
                         )
             except Exception:
                 logger.exception(

--- a/cfripper/rules/base_rules.py
+++ b/cfripper/rules/base_rules.py
@@ -65,7 +65,7 @@ class Rule(ABC):
                     rule_mode = rule_filter.rule_mode or rule_mode
                     if self._config.metrics_logger:
                         self._config.metrics_logger(
-                            rule=self.__class__.__name__, filter_reason=rule_filter.reason[:4000]
+                            rule=self.__class__.__name__[:4000], filter_reason=rule_filter.reason[:4000]
                         )
             except Exception:
                 logger.exception(

--- a/tests/config/test_filter.py
+++ b/tests/config/test_filter.py
@@ -303,6 +303,7 @@ def test_exist_function_and_property_exists(template_cross_account_role_with_nam
         stack_name="mockstack",
         rules_filters=[
             Filter(
+                reason="x" * 5000,
                 rule_mode=RuleMode.ALLOWED,
                 eval={
                     "and": [
@@ -326,7 +327,7 @@ def test_exist_function_and_property_exists(template_cross_account_role_with_nam
     result = processor.process_cf_template(template_cross_account_role_with_name, mock_config)
 
     assert result.valid
-    mock_metrics_logger.assert_called()
+    mock_metrics_logger.assert_called_with(rule="CrossAccountTrustRule", filter_reason="x" * 4000)
     assert compare_lists_of_failures(result.failures, [])
 
 


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change, how this updates the current logic and which features are added or removed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Truncate reason field to avoid overloading metrics logger

## Checklist

- [x] I have updated the CHANGELOG.md file accordingly
