### PR TITLE
Fix Read the Docs build by using uv for dependency management

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,5 +10,5 @@ build:
     - asdf plugin add uv
     - asdf install uv latest
     - asdf global uv latest
-    - uv sync --group docs
+    - uv sync --group docs --frozen
     - uv run mkdocs build --clean --site-dir $READTHEDOCS_OUTPUT/html --config-file mkdocs.yml

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,19 +1,14 @@
 version: 2
 
-mkdocs:
-  configuration: mkdocs.yml
-
 formats: all
 
 build:
   os: ubuntu-22.04
   tools:
     python: "3.10"
-
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - dev
-        - docs
+  commands:
+    - asdf plugin add uv
+    - asdf install uv latest
+    - asdf global uv latest
+    - uv sync --group docs
+    - uv run mkdocs build --clean --site-dir $READTHEDOCS_OUTPUT/html --config-file mkdocs.yml

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,8 +7,6 @@ build:
   tools:
     python: "3.10"
   commands:
-    - asdf plugin add uv
-    - asdf install uv latest
-    - asdf global uv latest
+    - pip install uv
     - uv sync --group docs --frozen
     - uv run mkdocs build --clean --site-dir $READTHEDOCS_OUTPUT/html --config-file mkdocs.yml


### PR DESCRIPTION
## Summary
- Read the Docs build was failing because `.readthedocs.yaml` used `extra_requirements: [dev, docs]` which maps to `[project.optional-dependencies]`, but the project migrated to `[dependency-groups]` (PEP 735) with uv in #356
- This caused `mkdocs-material` to not be installed (`WARNING: cfripper 1.20.0 does not provide the extra 'docs'`), breaking the docs build
- Switch to `build.commands` with uv to properly install dependency groups via `uv sync --group docs`

## Test plan
- [ ] Trigger a Read the Docs build and verify it succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)