### PR TITLE
Prefer `--locked` to `--frozen`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ CFRipper is a library and CLI security analyzer for AWS CloudFormation templates
 - `make install-dev` - Install development dependencies
 - `make install-docs` - Install docs dependencies
 - `make test` - Run lint + unit tests
-- `make unit` - Run unit tests only (`uv run --frozen pytest -svvv tests`)
+- `make unit` - Run unit tests only (`uv run --locked pytest -svvv tests`)
 - `make lint` - Run ruff linter
 - `make format` - Format code with ruff
 - `make coverage` - Run tests with coverage
@@ -23,7 +23,7 @@ CFRipper is a library and CLI security analyzer for AWS CloudFormation templates
 - `docs/` - MkDocs documentation source
 - `pyproject.toml` - Project metadata and dependencies
 - `uv.lock` - Locked dependencies (managed by uv)
-- `Makefile` - All dev commands use `uv run --frozen`
+- `Makefile` - All dev commands use `uv run --locked`
 
 ## Dependencies
 

--- a/Makefile
+++ b/Makefile
@@ -1,31 +1,31 @@
 SOURCES = cfripper tests docs
 
 install:
-	uv sync --no-dev --frozen
+	uv sync --no-dev --locked
 
 install-dev:
-	uv sync --group dev --frozen
+	uv sync --group dev --locked
 
 install-docs:
-	uv sync --group docs --frozen
+	uv sync --group docs --locked
 
 format:
-	uv run --frozen ruff format $(SOURCES)
-	uv run --frozen ruff check --fix $(SOURCES)
+	uv run --locked ruff format $(SOURCES)
+	uv run --locked ruff check --fix $(SOURCES)
 
 lint:
-	uv run --frozen ruff check $(SOURCES)
+	uv run --locked ruff check $(SOURCES)
 
 unit:
-	uv run --frozen pytest -svvv tests
+	uv run --locked pytest -svvv tests
 
 coverage:
-	uv run --frozen pytest --cov cfripper
+	uv run --locked pytest --cov cfripper
 
 test: lint unit
 
 test-docs:
-	uv run --frozen mkdocs build --strict
+	uv run --locked mkdocs build --strict
 
 lock:
 	uv lock
@@ -37,6 +37,6 @@ build:
 	uv build
 
 check-package:
-	uv run --frozen twine check --strict dist/*
+	uv run --locked twine check --strict dist/*
 
 .PHONY: install install-dev install-docs format lint unit coverage test test-docs lock lock-upgrade build check-package


### PR DESCRIPTION
[COPP-9142](https://skyscanner.atlassian.net/browse/COPP-9142)
---

By approving this PR, you are confirming that you have adequately and effectively reviewed this change.

## How this change was made
Turbolift
- `uv lock` in root directory (addressing pre-existing drift)
- naive find/replace of `--frozen` with `--locked` across all files.
- naive find/replace of `UV_FROZEN` with `UV_LOCKED` across all files.

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>

[COPP-9142]: https://skyscanner.atlassian.net/browse/COPP-9142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ